### PR TITLE
Slight refactoring of RelationalSeriveInfo and UriInfo

### DIFF
--- a/core/src/main/java/org/springframework/cloud/service/UriBasedServiceInfo.java
+++ b/core/src/main/java/org/springframework/cloud/service/UriBasedServiceInfo.java
@@ -1,6 +1,8 @@
 package org.springframework.cloud.service;
 
+import org.springframework.cloud.util.StandardUriInfoFactory;
 import org.springframework.cloud.util.UriInfo;
+import org.springframework.cloud.util.UriInfoFactory;
 
 /**
  * Common class for all {@link ServiceInfo}s
@@ -9,21 +11,33 @@ import org.springframework.cloud.util.UriInfo;
  *
  */
 public abstract class UriBasedServiceInfo extends BaseServiceInfo {
-	private UriInfo uriInfo; 
+	private UriInfo uriInfo;
+
+  private static UriInfoFactory uriFactory = new StandardUriInfoFactory();
 
 	public UriBasedServiceInfo(String id, String scheme, String host, int port, String username, String password, String path) {
-		this(id, new UriInfo(scheme, host, port, username, password, path));
+		super(id);
+    this.uriInfo = getUriInfoFactory().createUri(scheme, host, port, username, password, path);
+    this.uriInfo = validateAndCleanUriInfo(uriInfo);
 	}
 	
 	public UriBasedServiceInfo(String id, String uriString) {
-		this(id, new UriInfo(uriString));
-	}
-	
-	private UriBasedServiceInfo(String id, UriInfo uriInfo) {
-		super(id);
-		this.uriInfo = validateAndCleanUriInfo(uriInfo);
-	}
-	
+    super(id);
+    this.uriInfo = getUriInfoFactory().createUri(uriString);
+    this.uriInfo = validateAndCleanUriInfo(uriInfo);
+  }
+
+  /**
+   * For URI-based (@link ServiceInfo}s which don't conform to the standard URI
+   * format, override this method in your own ServiceInfo class to return a
+   * {@link UriInfoFactory} which will create the appropriate URIs.
+   *
+   * @return your special UriInfoFactory
+   */
+  public UriInfoFactory getUriInfoFactory() {
+    return uriFactory;
+  }
+
 	@ServiceProperty(category="connection")
 	public String getUri() {
 		return uriInfo.getUri().toString();

--- a/core/src/main/java/org/springframework/cloud/service/common/RelationalServiceInfo.java
+++ b/core/src/main/java/org/springframework/cloud/service/common/RelationalServiceInfo.java
@@ -8,18 +8,17 @@ import org.springframework.cloud.service.UriBasedServiceInfo;
  *
  */
 public abstract class RelationalServiceInfo extends UriBasedServiceInfo {
-	protected String jdbcUrl;
-	
+
+  private String jdbcUrlDatabaseType;
+
 	public RelationalServiceInfo(String id, String uriString, String jdbcUrlDatabaseType) {
 		super(id, uriString);
-		this.jdbcUrl = 
-			String.format("jdbc:%s://%s:%d/%s?user=%s&password=%s", 
-					      jdbcUrlDatabaseType,
-					      getHost(), getPort(), getPath(), getUserName(), getPassword());
+    this.jdbcUrlDatabaseType = jdbcUrlDatabaseType;
 	}
 	
 	@ServiceProperty(category="connection")
 	public String getJdbcUrl() {
-		return jdbcUrl;
+		return  String.format("jdbc:%s://%s:%d/%s?user=%s&password=%s",
+        jdbcUrlDatabaseType, getHost(), getPort(), getPath(), getUserName(), getPassword());
 	}
 }

--- a/core/src/main/java/org/springframework/cloud/util/StandardUriInfoFactory.java
+++ b/core/src/main/java/org/springframework/cloud/util/StandardUriInfoFactory.java
@@ -1,0 +1,67 @@
+package org.springframework.cloud.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+
+/**
+ * Factory for standard Cloud Foundry URIs which all conform to the format:
+ *
+ *   [jdbc:]scheme://[user:pass]@authority/path
+ */
+public class StandardUriInfoFactory implements UriInfoFactory {
+  @Override
+  public UriInfo createUri(String uriString) {
+    String userName = null;
+    String password = null;
+    String path;
+    URI tmpUri;
+
+    if (uriString.startsWith("jdbc:")) {
+      int idx = uriString.indexOf(":");
+      uriString = uriString.substring(idx + 1);
+    }
+
+    try {
+      tmpUri = new URI(uriString);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    String userInfo = tmpUri.getRawUserInfo();
+    if (userInfo != null) {
+      String userPass[] = userInfo.split(":");
+      if (userPass.length != 2) {
+        throw new IllegalArgumentException("bad user info in URI: " + tmpUri);
+      }
+
+      userName = uriDecode(userPass[0]);
+      password = uriDecode(userPass[1]);
+    }
+
+    String rawPath = tmpUri.getRawPath();
+    if (rawPath != null && rawPath.length() > 1) {
+      path = rawPath.substring(1);
+    } else {
+      path = null;
+    }
+    return new UriInfo(tmpUri.getScheme(), tmpUri.getHost(), tmpUri.getPort(), userName, password, path);
+  }
+
+  @Override
+  public UriInfo createUri(String scheme, String host, int port,
+      String username, String password, String path) {
+    return new UriInfo(scheme, host, port, username, password, path);
+  }
+
+  private static String uriDecode(String s) {
+    try {
+      // URLDecode decodes '+' to a space, as for
+      // form encoding.  So protect plus signs.
+      return URLDecoder.decode(s.replace("+", "%2B"), "US-ASCII");
+    } catch (java.io.UnsupportedEncodingException e) {
+      // US-ASCII is always supported
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/src/main/java/org/springframework/cloud/util/UriInfo.java
+++ b/core/src/main/java/org/springframework/cloud/util/UriInfo.java
@@ -2,7 +2,6 @@ package org.springframework.cloud.util;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 
 /**
  * Utility class that allows expressing URIs in alternative forms: individual fields or a URI string
@@ -12,15 +11,13 @@ import java.net.URLDecoder;
  */
 public class UriInfo {
 	private String scheme;
-	
 	private String host;
 	private int port;
 	private String userName;
 	private String password;
 	private String path;
-
 	private URI uri;
-	
+
 	public UriInfo(String scheme, String host, int port, String username, String password, String path) {
 		this.scheme = scheme;
 		this.host = host;
@@ -28,45 +25,15 @@ public class UriInfo {
 		this.userName = username;
 		this.password = password;
 		this.path = path;
-		
+
 		this.uri = buildUri();
 	}
 
 	public UriInfo(String scheme, String host, int port, String username, String password) {
 		this(scheme, host, port, username, password, "");
 	}
-	
-	public UriInfo(String uriString) throws IllegalArgumentException {
-		try {
-			this.uri = new URI(uriString);
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
-		}
 
-		scheme = uri.getScheme();
-		host = uri.getHost();
-		port = uri.getPort();
-
-		String userInfo = uri.getRawUserInfo();
-		if (userInfo != null) {
-			String userPass[] = userInfo.split(":");
-			if (userPass.length != 2) {
-				throw new IllegalArgumentException("bad user info in URI: " + uri);
-			}
-
-			userName = uriDecode(userPass[0]);
-			password = uriDecode(userPass[1]);
-		} 
-
-		String rawPath = uri.getRawPath();
-		if (rawPath != null && rawPath.length() > 1) {
-			path = rawPath.substring(1);
-		} else {
-			path = null;
-		}
-	}
-	
-	public String getScheme() {
+  public String getScheme() {
 		return scheme;
 	}
 
@@ -94,7 +61,7 @@ public class UriInfo {
 		return uri;
 	}
 
-	private URI buildUri() throws IllegalArgumentException {
+	public URI buildUri() throws IllegalArgumentException {
 		String userInfo = null;
 		
 		if (userName != null && password != null) {
@@ -111,17 +78,6 @@ public class UriInfo {
 		}
 	}
 
-	private String uriDecode(String s) {
-		try {
-			// URLDecode decodes '+' to a space, as for
-			// form encoding.  So protect plus signs.
-			return URLDecoder.decode(s.replace("+", "%2B"),	 "US-ASCII");
-		} catch (java.io.UnsupportedEncodingException e) {
-			// US-ASCII is always supported
-			throw new RuntimeException(e);
-		}
-	}
-	
 	@Override
 	public String toString() {
 		return uri.toString();

--- a/core/src/main/java/org/springframework/cloud/util/UriInfoFactory.java
+++ b/core/src/main/java/org/springframework/cloud/util/UriInfoFactory.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.util;
+
+/**
+ * An interface implemented in order to create {@link UriInfo}s.
+ *
+ * If your {@link org.springframework.cloud.service.ServiceInfo} needs to deal
+ * with special URIs and you are extending {@link org.springframework.cloud.service.UriBasedServiceInfo}
+ * then you can implement this factory interface in order to return a custom
+ * factory from your ServiceInfo by overriding {@link org.springframework.cloud.service.UriBasedServiceInfo#getUriInfoFactory()}.
+ *
+ * @author Jens Deppe
+ */
+public interface UriInfoFactory {
+
+  /**
+   * Create a {@link UriInfo} based on a URI string
+   * @param uriString the URI string to parse
+   * @return a {@link UriInfo}
+   */
+  public UriInfo createUri(String uriString);
+
+  /**
+   * Create a {@link UriInfo} based on explicit components of the URI
+   * @param scheme
+   * @param host
+   * @param port
+   * @param username
+   * @param password
+   * @param path
+   * @return a {@link UriInfo}
+   */
+  public UriInfo createUri(String scheme, String host, int port, String username, String password, String path);
+}

--- a/core/src/test/java/org/springframework/cloud/StandardUriInfoFactoryTest.java
+++ b/core/src/test/java/org/springframework/cloud/StandardUriInfoFactoryTest.java
@@ -1,0 +1,91 @@
+package org.springframework.cloud;
+
+import org.junit.Test;
+import org.springframework.cloud.util.StandardUriInfoFactory;
+import org.springframework.cloud.util.UriInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Jens Deppe
+ */
+public class StandardUriInfoFactoryTest {
+
+  private static StandardUriInfoFactory factory = new StandardUriInfoFactory();
+
+  /**
+   * Basic sanity
+   */
+  @Test
+  public void createUri1() {
+    String uri = "mysql://joe:joes_password@localhost:1527/big_db";
+    UriInfo result = factory.createUri(uri);
+
+    assertEquals("localhost", result.getHost());
+    assertEquals(1527, result.getPort());
+    assertEquals("joe", result.getUserName());
+    assertEquals("joes_password", result.getPassword());
+    assertEquals("big_db", result.getPath());
+    assertEquals(uri, result.buildUri().toString());
+  }
+
+  /**
+   * Test with a 'jdbc:...' URI
+   */
+  @Test
+  public void createUri2() {
+    String uri = "mysql://joe:joes_password@localhost:1527/big_db";
+    String jdbcUri = "jdbc:" + uri;
+    UriInfo result = factory.createUri(jdbcUri);
+
+    assertEquals("localhost", result.getHost());
+    assertEquals(1527, result.getPort());
+    assertEquals("joe", result.getUserName());
+    assertEquals("joes_password", result.getPassword());
+    assertEquals("big_db", result.getPath());
+    assertEquals(uri, result.buildUri().toString());
+  }
+
+  /**
+   * Test without user/password
+   */
+  @Test
+  public void createUri3() {
+    String uri = "mysql://localhost:1527/big_db";
+    UriInfo result = factory.createUri(uri);
+
+    assertEquals("localhost", result.getHost());
+    assertEquals(1527, result.getPort());
+    assertNull(result.getUserName());
+    assertNull(result.getPassword());
+    assertEquals("big_db", result.getPath());
+    assertEquals(uri, result.buildUri().toString());
+  }
+
+  /**
+   * Test with just a user and no password
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void createUri4() {
+    String uri = "mysql://joe@localhost:1527/big_db";
+    factory.createUri(uri);
+  }
+
+  /**
+   * Test when creating URI with explicit components
+   */
+  @Test
+  public void createUri5() {
+    String uri = "mysql://joe:joes_password@localhost:1527/big_db";
+    UriInfo result = factory.createUri("mysql", "localhost", 1527, "joe",
+        "joes_password", "big_db");
+
+    assertEquals("localhost", result.getHost());
+    assertEquals(1527, result.getPort());
+    assertEquals("joe", result.getUserName());
+    assertEquals("joes_password", result.getPassword());
+    assertEquals("big_db", result.getPath());
+    assertEquals(uri, result.buildUri().toString());
+  }
+}


### PR DESCRIPTION
This allows for extending RelationalServiceInfo when using URIs that don't conform to the expectations of UriInfo.

In particular, the URIs I need to work with don't like like this: `scheme://[user@password]location`, but rather: `scheme://location;user=name;password=secret;attr1=param1;attr2=param2`, so they need to be parsed differently to what UriInfo can handle.

Let me know if you think there's a better approach to this...
