### PR TITLE
Added service connectors for Cloud Foundry user-provided services.

### DIFF
--- a/cloudfoundry-connector/build.gradle
+++ b/cloudfoundry-connector/build.gradle
@@ -1,4 +1,4 @@
-description = 'Spring-Cloud CloudFoundry Connector'
+description = 'Spring-Cloud Cloud Foundry Connector'
 
 buildscript {
     repositories {
@@ -35,3 +35,18 @@ task moveShadowJar(type: Copy) {
 moveShadowJar.dependsOn shadowJar
 assemble.dependsOn moveShadowJar
 install.dependsOn moveShadowJar
+
+configurations {
+    tests
+}
+
+task testJar(type: Jar) {
+    classifier = 'tests'
+    from sourceSets.test.output.classesDir
+}
+
+build.dependsOn testJar
+
+artifacts {
+    tests testJar
+}

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFactoryConnectorTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFactoryConnectorTest.java
@@ -55,7 +55,9 @@ public abstract class AbstractCloudFactoryConnectorTest {
 			scanner = new Scanner(fileReader);
 			return scanner.useDelimiter("\\Z").next();
 		} finally {
-			scanner.close();
+			if (scanner != null) {
+				scanner.close();
+			}
 		}
 	}
 	
@@ -78,7 +80,7 @@ public abstract class AbstractCloudFactoryConnectorTest {
 		int i = 0;
 
 		for (Map.Entry<String, List<String>> entry : labelPayloadMap.entrySet()) {
-			result.append(quote(entry.getKey()) + ":");
+			result.append(quote(entry.getKey())).append(":");
 			result.append(getServicePayload(entry.getValue()));
 			if (i++ != labelSize-1) {
 				result.append(",\n");

--- a/cloudfoundry-ups-connector/README.md
+++ b/cloudfoundry-ups-connector/README.md
@@ -1,0 +1,26 @@
+Cloud Foundry user-provided connector for spring-cloud
+======================================================
+
+Provides Cloud Foundry connector with support for user-provided Mysql, Postgres, Oracle, and RabbitMQ services.
+
+Cloud Foundry allows service connection information and credentials to be provided by a user. The credentials can take
+form, but the connectors in this module expect the service to be created with a single `uri` field in the credentials,
+using the form `<scheme>://<username>:<password>@<hostname>:<port>/<name>`.
+
+The examples below show the command to create user-provided services for each of the supported service types, using a
+`uri` field that the connectors in this module will detect.
+
+~~~
+# create a user-provided Oracle database service instance
+$ cf create-user-provided-service oracle-db -p '{"uri":"oracle://username:password@dbserver.example.com:1521/mydatabase"}'
+
+# create a user-provided MySQL database service instance
+$ cf create-user-provided-service mysql-db -p '{"uri":"mysql://username:password@dbserver.example.com:3306/mydatabase"}'
+
+# create a user-provided PostgreSQL database service instance
+$ cf create-user-provided-service postgres-db -p '{"uri":"postgres://username:password@dbserver.example.com:5432/mydatabase"}'
+
+# create a user-provided RabbitMQ service instance
+$ cf create-user-provided-service rabbit-queue -p '{"uri":"amqp://username:password@rabbitserver.example.com:5672/virtualhost"}'
+~~~
+

--- a/cloudfoundry-ups-connector/build.gradle
+++ b/cloudfoundry-ups-connector/build.gradle
@@ -1,0 +1,7 @@
+description = 'Spring-Cloud Cloud Foundry User-provided Connector'
+
+dependencies {
+    compile project(':cloudfoundry-connector')
+    testCompile project(path: ':cloudfoundry-connector', configuration: 'tests')
+}
+

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedMysqlServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedMysqlServiceInfoCreator.java
@@ -1,0 +1,15 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.MysqlServiceInfo;
+
+public class UserProvidedMysqlServiceInfoCreator extends UserProvidedRelationalServiceInfoCreator<MysqlServiceInfo> {
+	public UserProvidedMysqlServiceInfoCreator() {
+		super("mysql:");
+	}
+
+	@Override
+	public MysqlServiceInfo createServiceInfo(String id, String url) {
+		return new MysqlServiceInfo(id, url);
+	}
+}
+

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreator.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.OracleServiceInfo;
+
+public class UserProvidedOracleServiceInfoCreator extends UserProvidedRelationalServiceInfoCreator<OracleServiceInfo> {
+	public UserProvidedOracleServiceInfoCreator() {
+		super("oracle:");
+	}
+
+	@Override
+	public OracleServiceInfo createServiceInfo(String id, String url) {
+		return new OracleServiceInfo(id, url);
+	}
+}

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedPostgresqlServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedPostgresqlServiceInfoCreator.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.PostgresqlServiceInfo;
+
+public class UserProvidedPostgresqlServiceInfoCreator extends UserProvidedRelationalServiceInfoCreator<PostgresqlServiceInfo> {
+	public UserProvidedPostgresqlServiceInfoCreator() {
+		super("postgres:");
+	}
+
+	@Override
+	public PostgresqlServiceInfo createServiceInfo(String id, String url) {
+		return new PostgresqlServiceInfo(id, url);
+	}
+}

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedRabbitServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedRabbitServiceInfoCreator.java
@@ -1,0 +1,24 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.RabbitServiceInfo;
+
+import java.util.Map;
+
+public class UserProvidedRabbitServiceInfoCreator extends UserProvidedServiceInfoCreator<RabbitServiceInfo> {
+
+	public UserProvidedRabbitServiceInfoCreator() {
+		super("amqp:");
+	}
+
+	public RabbitServiceInfo createServiceInfo(Map<String,Object> serviceData) {
+		@SuppressWarnings("unchecked")
+		Map<String,Object> credentials = (Map<String, Object>) serviceData.get("credentials");
+		
+		String id = (String) serviceData.get("name");
+
+		String uri = (String) credentials.get("uri");
+
+		return new RabbitServiceInfo(id, uri);
+	}
+
+}

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedRelationalServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedRelationalServiceInfoCreator.java
@@ -1,0 +1,31 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.RelationalServiceInfo;
+
+import java.util.Map;
+
+public abstract class UserProvidedRelationalServiceInfoCreator<SI extends RelationalServiceInfo> extends RelationalServiceInfoCreator<SI> {
+	private final String uriScheme;
+
+	public UserProvidedRelationalServiceInfoCreator(String uriScheme) {
+		super("user-provided");
+		this.uriScheme = uriScheme;
+	}
+
+	public abstract SI createServiceInfo(String id, String uri);
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean accept(Map<String, Object> serviceData) {
+		if (super.accept(serviceData)) {
+			Map<String, Object> credentials = (Map<String, Object>) serviceData.get("credentials");
+			String uri = (String) credentials.get("uri");
+
+			if (uri != null && uri.startsWith(uriScheme)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedServiceInfoCreator.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.ServiceInfo;
+
+import java.util.Map;
+
+public abstract class UserProvidedServiceInfoCreator<SI extends ServiceInfo> extends CloudFoundryServiceInfoCreator<SI> {
+	private final String uriScheme;
+
+	public UserProvidedServiceInfoCreator(String uriScheme) {
+		super("user-provided");
+		this.uriScheme = uriScheme;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean accept(Map<String, Object> serviceData) {
+		if (super.accept(serviceData)) {
+			Map<String, Object> credentials = (Map<String, Object>) serviceData.get("credentials");
+			String uri = (String) credentials.get("uri");
+
+			if (uri != null && uri.startsWith(uriScheme)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/cloudfoundry-ups-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
+++ b/cloudfoundry-ups-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
@@ -1,0 +1,4 @@
+org.springframework.cloud.cloudfoundry.UserProvidedMysqlServiceInfoCreator
+org.springframework.cloud.cloudfoundry.UserProvidedPostgresqlServiceInfoCreator
+org.springframework.cloud.cloudfoundry.UserProvidedOracleServiceInfoCreator
+org.springframework.cloud.cloudfoundry.UserProvidedRabbitServiceInfoCreator

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractUserProvidedServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractUserProvidedServiceInfoCreatorTest.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.cloudfoundry;
+
+public class AbstractUserProvidedServiceInfoCreatorTest extends AbstractCloudFoundryConnectorRelationalServiceTest {
+	protected String getUserProvidedServicePayload(String serviceName, String hostname, int port,
+												   String user, String password, String name, String scheme) {
+		String payload = getRelationalPayload("test-ups-info.json", "", serviceName,
+				hostname, port, user, password, name);
+		return payload.replace("$scheme", scheme);
+	}
+
+	protected String getUserProvidedServicePayloadWithNoUri(String serviceName, String hostname, int port,
+															String user, String password, String name) {
+		return getRelationalPayload("test-ups-info-no-uri.json", "", serviceName,
+				hostname, port, user, password, name);
+	}
+}

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedMysqlServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedMysqlServiceInfoCreatorTest.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.MysqlServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class UserProvidedMysqlServiceInfoCreatorTest extends AbstractUserProvidedServiceInfoCreatorTest {
+
+	private static final String INSTANCE_NAME = "database";
+	private static final String MYSQL_SCHEME = "mysql:";
+	private static final String SERVICE_NAME = "mysql-ups";
+
+	@Test
+	public void mysqlServiceCreation() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME, MYSQL_SCHEME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		MysqlServiceInfo info = (MysqlServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertNotNull(info);
+		assertEquals(getJdbcUrl("mysql", INSTANCE_NAME), info.getJdbcUrl());
+	}
+
+	@Test
+	public void mysqlServiceCreationWithNoUri() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayloadWithNoUri(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		BaseServiceInfo info = (BaseServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertFalse(MysqlServiceInfo.class.isAssignableFrom(info.getClass()));  // service was not detected as MySQL
+		assertNotNull(info);
+	}
+
+}

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreatorTest.java
@@ -1,0 +1,49 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.MysqlServiceInfo;
+import org.springframework.cloud.service.common.OracleServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class UserProvidedOracleServiceInfoCreatorTest extends AbstractUserProvidedServiceInfoCreatorTest {
+
+	private static final String INSTANCE_NAME = "database";
+	private static final String ORACLE_SCHEME = "oracle:";
+	private static final String SERVICE_NAME = "oracle-ups";
+
+	@Test
+	public void oracleServiceCreation() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME, ORACLE_SCHEME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		OracleServiceInfo info = (OracleServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertNotNull(info);
+		assertEquals(getOracleJdbcUrl(INSTANCE_NAME), info.getJdbcUrl());
+	}
+
+	@Test
+	public void oracleServiceCreationWithNoUri() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayloadWithNoUri(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		BaseServiceInfo info = (BaseServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertFalse(MysqlServiceInfo.class.isAssignableFrom(info.getClass()));  // service was not detected as MySQL
+		assertNotNull(info);
+	}
+
+	private String getOracleJdbcUrl(String name) {
+		return "jdbc:oracle:thin:" + username + "/" + password + "@" + hostname + ":" + port + "/" + name;
+	}
+}

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedPostgresqlServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedPostgresqlServiceInfoCreatorTest.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.MysqlServiceInfo;
+import org.springframework.cloud.service.common.PostgresqlServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class UserProvidedPostgresqlServiceInfoCreatorTest extends AbstractUserProvidedServiceInfoCreatorTest {
+
+	private static final String INSTANCE_NAME = "database";
+	private static final String POSTGRES_SCHEME = "postgres:";
+	private static final String SERVICE_NAME = "postgres-ups";
+
+	@Test
+	public void postgresServiceCreation() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME, POSTGRES_SCHEME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		PostgresqlServiceInfo info = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertNotNull(info);
+		assertEquals(getJdbcUrl("postgresql", INSTANCE_NAME), info.getJdbcUrl());
+	}
+
+	@Test
+	public void postgresServiceCreationWithNoUri() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayloadWithNoUri(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		BaseServiceInfo info = (BaseServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertFalse(MysqlServiceInfo.class.isAssignableFrom(info.getClass()));  // service was not detected as MySQL
+		assertNotNull(info);
+	}
+}

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedRabbitServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/UserProvidedRabbitServiceInfoCreatorTest.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+import org.springframework.cloud.service.ServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class UserProvidedRabbitServiceInfoCreatorTest extends AbstractCloudFactoryConnectorTest {
+	@Test
+	public void rabbitServiceCreationWithTags() {
+			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+					.thenReturn(getServicesPayload(
+							getRabbitServicePayload("rabbit", hostname, port, username, password, "vhost2")));
+
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		assertNotNull(getServiceInfo(serviceInfos, "rabbit"));
+	}
+
+	private String getRabbitServicePayload(String serviceName,
+										   String hostname, int port,
+										   String user, String password,
+										   String vHost) {
+		return getRabbitServicePayload("test-ups-info.json", serviceName,
+				hostname, port, user, password, vHost);
+	}
+
+	private String getRabbitServicePayload(String filename, String serviceName,
+										   String hostname, int port,
+										   String user, String password,
+										   String vHost) {
+		String payload = readTestDataFile(filename);
+		payload = payload.replace("$serviceName", serviceName);
+		payload = payload.replace("$hostname", hostname);
+		payload = payload.replace("$port", Integer.toString(port));
+		payload = payload.replace("$user", user);
+		payload = payload.replace("$pass", password);
+		payload = payload.replace("$name", vHost);
+
+		return payload;
+	}
+
+}

--- a/cloudfoundry-ups-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-ups-info-no-uri.json
+++ b/cloudfoundry-ups-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-ups-info-no-uri.json
@@ -1,0 +1,12 @@
+{
+    "name": "$serviceName",
+    "label": "user-provided",
+    "tags": [],
+    "credentials": {
+        "host": "$hostname",
+        "port": "$port",
+        "username": "$user",
+        "password": "$password",
+        "name": "$name"
+    }
+}

--- a/cloudfoundry-ups-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-ups-info.json
+++ b/cloudfoundry-ups-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-ups-info.json
@@ -1,0 +1,8 @@
+{
+    "name": "$serviceName",
+    "label": "user-provided",
+    "tags": [],
+    "credentials": {
+        "uri": "$scheme//$user:$password@$hostname:$port/$name"
+    }
+}

--- a/core/src/main/java/org/springframework/cloud/service/common/RabbitServiceInfo.java
+++ b/core/src/main/java/org/springframework/cloud/service/common/RabbitServiceInfo.java
@@ -56,7 +56,7 @@ public class RabbitServiceInfo extends UriBasedServiceInfo {
 			// Check that the path only has a single segment.  As we have an authority component
 			// in the URI, paths always begin with a slash.
 			if (path.indexOf('/') != -1) {
-				throw new IllegalArgumentException("multiple segemtns in path of amqp URI: " + uriInfo);
+				throw new IllegalArgumentException("multiple segments in path of amqp URI: " + uriInfo);
 			}
 		}
 		return new UriInfo(uriInfo.getScheme(), uriInfo.getHost(), port, uriInfo.getUserName(), uriInfo.getPassword(), path);

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,6 @@ rootProject.name = "spring-cloud"
 
 include 'core'
 include 'cloudfoundry-connector'
+include 'cloudfoundry-ups-connector'
 include 'spring-service-connector'
 include 'heroku-connector'

--- a/spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -1,5 +1,6 @@
 org.springframework.cloud.service.relational.MysqlDataSourceCreator
 org.springframework.cloud.service.relational.PostgresqlDataSourceCreator
+org.springframework.cloud.service.relational.OracleDataSourceCreator
 org.springframework.cloud.service.keyval.RedisConnectionFactoryCreator
 org.springframework.cloud.service.document.MongoDbFactoryCreator
 org.springframework.cloud.service.messaging.RabbitConnectionFactoryCreator


### PR DESCRIPTION
This PR adds Cloud Foundry service connectors for the most common types of user-provided services - MySQL, PostgreSQL, Oracle, and RabbitMQ. 
