### PR TITLE
Update coordinates of JavaMail dependency

### DIFF
--- a/spring-service-connector/build.gradle
+++ b/spring-service-connector/build.gradle
@@ -6,13 +6,14 @@ dependencies {
 
   compile("org.springframework:spring-context:$springVersion")
   compile("log4j:log4j:$log4jVersion")
-  
+
   testCompile("org.springframework:spring-test:$springVersion")
   testCompile("mysql:mysql-connector-java:$mysqlDriverVersion")
   testCompile("org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion")
   testCompile("postgresql:postgresql:$postgresDriverVersion")
-  testCompile("javax.mail:mail:$javaxMailVersion")
   testCompile("cglib:cglib-nodep:$cglibVersion")
+
+  testRuntime("javax.mail:javax.mail-api:$javaxMailVersion")
 
   optional("org.springframework:spring-jdbc:$springVersion")
   optional("org.springframework:spring-context-support:$springVersion")


### PR DESCRIPTION
JavaMail is moving towards using `javax.mail:javax.mail-api` as the coordinates for the JavaMail API (1.5 no longer publishes the `javax.mail:mail` artifact). This PR updates spring-cloud to use the new coordinates but leaves the version unchanged
