### PR TITLE
Update RabbitServiceInfoCreator.java

### DIFF
--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RabbitServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RabbitServiceInfoCreator.java
@@ -22,7 +22,9 @@ public class RabbitServiceInfoCreator extends CloudFoundryServiceInfoCreator<Rab
 		String id = (String) serviceData.get("name");
 		
 		String uri = (String) credentials.get("uri");
-
+		if (uri == null || uri.length() == 0)
+			uri = (String) credentials.get("url");
+			
 		return new RabbitServiceInfo(id, uri);
 	}
 


### PR DESCRIPTION
Adding support for older Version of RabbitMQ API, with URL instead of URI, which is currently used in API v2 and all Pivotal Instances.
