### PR TITLE
Multiple tag support and refactoring accept().

### DIFF
--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/AmqpServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/AmqpServiceInfoCreator.java
@@ -12,7 +12,7 @@ import org.springframework.cloud.service.common.AmqpServiceInfo;
 public class AmqpServiceInfoCreator extends CloudFoundryServiceInfoCreator<AmqpServiceInfo> {
 
 	public AmqpServiceInfoCreator() {
-		super("rabbitmq", "amqp");
+		super(new Tags("rabbitmq"), "amqp");
 	}
 
 	public AmqpServiceInfo createServiceInfo(Map<String,Object> serviceData) {

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MongoServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MongoServiceInfoCreator.java
@@ -12,7 +12,7 @@ import org.springframework.cloud.service.common.MongoServiceInfo;
 public class MongoServiceInfoCreator extends CloudFoundryServiceInfoCreator<MongoServiceInfo> {
 
 	public MongoServiceInfoCreator() {
-		super("mongodb", "mongodb");
+		super(new Tags("mongodb"), "mongodb");
 
 	}
 

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MonitoringServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MonitoringServiceInfoCreator.java
@@ -5,24 +5,22 @@ import java.util.Map;
 import org.springframework.cloud.service.common.MonitoringServiceInfo;
 
 /**
- * 
  * @author Ramnivas Laddad
- *
  */
 public class MonitoringServiceInfoCreator extends CloudFoundryServiceInfoCreator<MonitoringServiceInfo> {
-    public MonitoringServiceInfoCreator() {
-        super("monitoring");
-    }
+	public MonitoringServiceInfoCreator() {
+		super(new Tags("monitoring", "newrelic"));
+	}
 
-    // Until NewRelic service payload contains tags, we have to go with overriding to check the label
-    @Override
-    public boolean accept(Map<String,Object> serviceData) {
-        return ((String) serviceData.get("label")).startsWith("newrelic");
-    }
+	// Until NewRelic service payload contains tags, we have to go with overriding to check the label
+	@Override
+	public boolean accept(Map<String, Object> serviceData) {
+		return labelStartsWithTag(serviceData);
+	}
 
-    @Override
-    public MonitoringServiceInfo createServiceInfo(Map<String,Object> serviceData) {
-        String id = (String) serviceData.get("name");
-        return new MonitoringServiceInfo(id);
-    }
+	@Override
+	public MonitoringServiceInfo createServiceInfo(Map<String, Object> serviceData) {
+		String id = (String) serviceData.get("name");
+		return new MonitoringServiceInfo(id);
+	}
 }

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MysqlServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MysqlServiceInfoCreator.java
@@ -10,7 +10,7 @@ import org.springframework.cloud.service.common.MysqlServiceInfo;
 public class MysqlServiceInfoCreator extends RelationalServiceInfoCreator<MysqlServiceInfo> {
 
 	public MysqlServiceInfoCreator() {
-		super("mysql", "mysql");
+		super(new Tags("mysql"), "mysql");
 	}
 
 	@Override

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/PostgresqlServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/PostgresqlServiceInfoCreator.java
@@ -10,7 +10,7 @@ import org.springframework.cloud.service.common.PostgresqlServiceInfo;
 public class PostgresqlServiceInfoCreator extends RelationalServiceInfoCreator<PostgresqlServiceInfo> {
 
 	public PostgresqlServiceInfoCreator() {
-		super("postgresql", "postgres");
+		super(new Tags("postgresql"), "postgres");
 	}
 
 	@Override

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RedisServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RedisServiceInfoCreator.java
@@ -5,35 +5,34 @@ import java.util.Map;
 import org.springframework.cloud.service.common.RedisServiceInfo;
 
 /**
- * 
+ *
  * @author Ramnivas Laddad
  *
  */
 public class RedisServiceInfoCreator extends CloudFoundryServiceInfoCreator<RedisServiceInfo> {
 
 	public RedisServiceInfoCreator() {
-		super("redis", "redis");
-
+		super(new Tags("redis"), "redis");
 	}
 
 	public RedisServiceInfo createServiceInfo(Map<String,Object> serviceData) {
 		@SuppressWarnings("unchecked")
-		Map<String,Object> credentials = (Map<String, Object>) serviceData.get("credentials");
-		
+		Map<String, Object> credentials = (Map<String, Object>) serviceData.get("credentials");
+
 		String id = (String) serviceData.get("name");
 
 		String uri = (String) credentials.get("uri");
 		if (uri == null) {
-		    uri = (String) credentials.get("url");
+			uri = (String) credentials.get("url");
 		}
 		if (uri == null) {
-        		String host = (String) credentials.get("hostname");
-        		Integer port = Integer.parseInt(credentials.get("port").toString());
-        		String password = (String) credentials.get("password");
-        
-        		return new RedisServiceInfo(id, host, port, password);
+			String host = (String) credentials.get("hostname");
+			Integer port = Integer.parseInt(credentials.get("port").toString());
+			String password = (String) credentials.get("password");
+
+			return new RedisServiceInfo(id, host, port, password);
 		} else {
-		    return new RedisServiceInfo(id, uri);
+			return new RedisServiceInfo(id, uri);
 		}
 	}
 

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RelationalServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RelationalServiceInfoCreator.java
@@ -12,24 +12,19 @@ import org.springframework.cloud.util.UriInfo;
  */
 public abstract class RelationalServiceInfoCreator<SI extends RelationalServiceInfo> extends CloudFoundryServiceInfoCreator<SI> {
 
-	public RelationalServiceInfoCreator(String tag, String uriScheme) {
-		super(tag, uriScheme);
+	public RelationalServiceInfoCreator(Tags tags, String uriScheme) {
+		super(tags, uriScheme);
 	}
 
 	public abstract SI createServiceInfo(String id, String uri);
-	
-	protected String getConnectionScheme() {
-		 // by default return the tag as the uri scheme
-		return getTag();
-	}
-	
+
 	public SI createServiceInfo(Map<String,Object> serviceData) {
 		@SuppressWarnings("unchecked")
 		Map<String,Object> credentials = (Map<String, Object>) serviceData.get("credentials");
-		
+
 		String id = (String) serviceData.get("name");
-		
-		String uri = null;
+
+		String uri;
 		if (credentials.containsKey("uri")) {
 			uri = credentials.get("uri").toString();
 		} else {
@@ -41,7 +36,7 @@ public abstract class RelationalServiceInfoCreator<SI extends RelationalServiceI
 
 			String database = (String) credentials.get("name");
 			
-			uri = new UriInfo(getConnectionScheme(), host, port, username, password, database).toString();
+			uri = new UriInfo(getUriScheme(), host, port, username, password, database).toString();
 		}
 		return createServiceInfo(id, uri);
 	}

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/SmtpServiceInfoCreator.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/SmtpServiceInfoCreator.java
@@ -15,7 +15,7 @@ public class SmtpServiceInfoCreator extends CloudFoundryServiceInfoCreator<SmtpS
 	private static final int DEFAULT_SMTP_PORT = 587;
 
 	public SmtpServiceInfoCreator() {
-		super("smtp", "smtp");
+		super(new Tags("smtp"), "smtp");
 	}
 
 	public SmtpServiceInfo createServiceInfo(Map<String,Object> serviceData) {

--- a/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/Tags.java
+++ b/cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/Tags.java
@@ -1,0 +1,42 @@
+package org.springframework.cloud.cloudfoundry;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Tags {
+	private String[] values;
+
+	public Tags(String... values) {
+		this.values = values;
+	}
+
+	public String[] getTags() {
+		return values;
+	}
+
+	public boolean containsOne(List<String> tags) {
+		if (tags != null) {
+			for (String value : values) {
+				if (tags.contains(value)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	public boolean contains(String tag) {
+		return tag != null && Arrays.asList(values).contains(tag);
+	}
+
+	public boolean startsWith(String tag) {
+		if (tag != null) {
+			for (String value : values) {
+				if (tag.startsWith(value)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/TagsTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/TagsTest.java
@@ -1,0 +1,51 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TagsTest {
+
+	private final Tags EMPTY_TAGS = new Tags();
+
+	@Test
+	public void containsOne() {
+		Tags tags = new Tags("test1", "test2");
+		assertTrue(tags.containsOne(Arrays.asList("test1", "testx")));
+		assertTrue(tags.containsOne(Arrays.asList("testx", "test2")));
+		assertFalse(tags.containsOne(Arrays.asList("testx", "testy")));
+	}
+
+	@Test
+	public void containsOneWithEmptyTags() {
+		assertFalse(EMPTY_TAGS.containsOne(Arrays.asList("test")));
+	}
+
+	@Test
+	public void contains() {
+		Tags tags = new Tags("test1", "test2");
+		assertTrue(tags.contains("test1"));
+		assertTrue(tags.contains("test2"));
+		assertFalse(tags.contains("testx"));
+	}
+
+	@Test
+	public void containsWithEmptyTags() {
+		assertFalse(EMPTY_TAGS.contains("test"));
+	}
+
+	@Test
+	public void startsWith() {
+		Tags tags = new Tags("test");
+		assertTrue(tags.startsWith("test-123"));
+		assertFalse(tags.startsWith("abcd"));
+	}
+
+	@Test
+	public void startsWithWithEmptyTags() {
+		assertFalse(EMPTY_TAGS.startsWith("test"));
+	}
+}

--- a/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreator.java
+++ b/cloudfoundry-ups-connector/src/main/java/org/springframework/cloud/cloudfoundry/UserProvidedOracleServiceInfoCreator.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.service.common.OracleServiceInfo;
 
 public class UserProvidedOracleServiceInfoCreator extends RelationalServiceInfoCreator<OracleServiceInfo> {
 	public UserProvidedOracleServiceInfoCreator() {
-		super("oracle", "oracle");
+		super(new Tags(), "oracle");
 	}
 
 	@Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 20 12:11:25 PDT 2014
+#Mon May 12 12:50:01 CDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip


### PR DESCRIPTION
- Added the ability to provide multiple tags for ServiceInfoCreators. 
- Refactored CloudFoundryServiceInfoCreator.accept into a set of composite methods so subclasses can easily override with a different composition.
