### PR TITLE
Removed reference to service versions from service connector test cases.

### DIFF
--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorRelationalServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorRelationalServiceTest.java
@@ -6,10 +6,9 @@ package org.springframework.cloud.cloudfoundry;
  *
  */
 public abstract class AbstractCloudFoundryConnectorRelationalServiceTest extends AbstractCloudFoundryConnectorTest {
-	protected String getRelationalPayload(String templateFile, String version, String serviceName, 
+	protected String getRelationalPayload(String templateFile, String serviceName,
 			                              String hostname, int port, String user, String password, String name) {
 		String payload = readTestDataFile(templateFile);
-		payload = payload.replace("$version", version);
 		payload = payload.replace("$serviceName", serviceName);
 		payload = payload.replace("$hostname", hostname);
 		payload = payload.replace("$port", Integer.toString(port));

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorAmqpServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorAmqpServiceTest.java
@@ -16,13 +16,22 @@ import org.springframework.cloud.service.ServiceInfo;
 public class CloudFoundryConnectorAmqpServiceTest extends AbstractCloudFoundryConnectorTest {
 	@Test
 	public void rabbitServiceCreationWithTags() {
-		String[] versions = {"2.0", "2.2"};
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+					getRabbitServicePayloadWithTags("rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
+					getRabbitServicePayloadWithTags("rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
+
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		assertNotNull(getServiceInfo(serviceInfos, "rabbit-1"));
+		assertNotNull(getServiceInfo(serviceInfos, "rabbit-2"));
+	}
+
+	@Test
+	public void rabbitServiceCreationWithoutTags() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
 				.thenReturn(getServicesPayload(
-				        getRabbitServicePayloadWithTags(version, "rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
-				        getRabbitServicePayloadWithTags(version, "rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
-		}
+						getRabbitServicePayloadWithoutTags("rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
+						getRabbitServicePayloadWithoutTags("rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
 
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		assertNotNull(getServiceInfo(serviceInfos, "rabbit-1"));
@@ -30,74 +39,55 @@ public class CloudFoundryConnectorAmqpServiceTest extends AbstractCloudFoundryCo
 	}
 
     @Test
-    public void rabbitServiceCreationWithoutTags() {
-        String[] versions = {"1.0", "1.1"};
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                        getRabbitServicePayloadWithoutTags(version, "rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
-                        getRabbitServicePayloadWithoutTags(version, "rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
-        }
-
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        assertNotNull(getServiceInfo(serviceInfos, "rabbit-1"));
-        assertNotNull(getServiceInfo(serviceInfos, "rabbit-2"));
-    }
-
-    @Test
     public void rabbitServiceCreationNoLabelNoTags() {
-        String[] versions = {"1.0", "1.1"};
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                        getRabbitServicePayloadNoLabelNoTags(version, "rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
-                        getRabbitServicePayloadNoLabelNoTags(version, "rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
-        }
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+					getRabbitServicePayloadNoLabelNoTags("rabbit-1", hostname, port, username, password, "q-1", "vhost1"),
+					getRabbitServicePayloadNoLabelNoTags("rabbit-2", hostname, port, username, password, "q-2", "vhost2")));
 
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        assertNotNull(getServiceInfo(serviceInfos, "rabbit-1"));
-        assertNotNull(getServiceInfo(serviceInfos, "rabbit-2"));
-    }
-
-    private String getRabbitServicePayloadWithoutTags(String version, String serviceName,
-            String hostname, int port,
-            String user, String password, String name,
-            String vHost) {
-        return getRabbitServicePayload("test-rabbit-info-with-label-no-tags.json", version, serviceName, 
-                                       hostname, port, user, password, name, vHost);
-    }
-
-    private String getRabbitServicePayloadNoLabelNoTags(String version, String serviceName,
-            String hostname, int port,
-            String user, String password, String name,
-            String vHost) {
-        return getRabbitServicePayload("test-rabbit-info-no-label-no-tags.json", version, serviceName, 
-                                       hostname, port, user, password, name, vHost);
-    }
-    
-	private String getRabbitServicePayloadWithTags(String version, String serviceName,
-                                			  String hostname, int port,
-                                			  String user, String password, String name,
-                                			  String vHost) {
-		return getRabbitServicePayload("test-rabbit-info.json", version, serviceName, 
-		                               hostname, port, user, password, name, vHost);
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		assertNotNull(getServiceInfo(serviceInfos, "rabbit-1"));
+		assertNotNull(getServiceInfo(serviceInfos, "rabbit-2"));
 	}
 
-    private String getRabbitServicePayload(String filename, String version, String serviceName,
-                                           String hostname, int port,
-                                           String user, String password, String name,
-                                           String vHost) {
-        String payload = readTestDataFile(filename);
-        payload = payload.replace("$version", version);
-        payload = payload.replace("$serviceName", serviceName);
-        payload = payload.replace("$hostname", hostname);
-        payload = payload.replace("$port", Integer.toString(port));
-        payload = payload.replace("$user", user);
-        payload = payload.replace("$pass", password);
-        payload = payload.replace("$name", name);
-        payload = payload.replace("$virtualHost", vHost);
-        
-        return payload;
-    }
+	private String getRabbitServicePayloadWithoutTags(String serviceName,
+													  String hostname, int port,
+													  String user, String password, String name,
+													  String vHost) {
+		return getRabbitServicePayload("test-rabbit-info-with-label-no-tags.json", serviceName,
+				hostname, port, user, password, name, vHost);
+	}
+
+	private String getRabbitServicePayloadNoLabelNoTags(String serviceName,
+														String hostname, int port,
+														String user, String password, String name,
+														String vHost) {
+		return getRabbitServicePayload("test-rabbit-info-no-label-no-tags.json", serviceName,
+				hostname, port, user, password, name, vHost);
+	}
+
+	private String getRabbitServicePayloadWithTags(String serviceName,
+												   String hostname, int port,
+												   String user, String password, String name,
+												   String vHost) {
+		return getRabbitServicePayload("test-rabbit-info.json", serviceName,
+				hostname, port, user, password, name, vHost);
+	}
+
+	private String getRabbitServicePayload(String filename, String serviceName,
+										   String hostname, int port,
+										   String user, String password, String name,
+										   String vHost) {
+		String payload = readTestDataFile(filename);
+		payload = payload.replace("$serviceName", serviceName);
+		payload = payload.replace("$hostname", hostname);
+		payload = payload.replace("$port", Integer.toString(port));
+		payload = payload.replace("$user", user);
+		payload = payload.replace("$pass", password);
+		payload = payload.replace("$name", name);
+		payload = payload.replace("$virtualHost", vHost);
+
+		return payload;
+	}
 	
 }

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorMongodbServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorMongodbServiceTest.java
@@ -16,13 +16,10 @@ import org.springframework.cloud.service.ServiceInfo;
 public class CloudFoundryConnectorMongodbServiceTest extends AbstractCloudFoundryConnectorTest {
 	@Test
 	public void mongoServiceCreation() {
-		String[] versions = {"2.0", "2.2"};
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-				.thenReturn(getServicesPayload(
-						getMongoServicePayload(version, "mongo-1", hostname, port, username, password, "inventory-1", "db"),
-						getMongoServicePayload(version, "mongo-2", hostname, port, username, password, "inventory-2", "db")));
-		}
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+					getMongoServicePayload("mongo-1", hostname, port, username, password, "inventory-1", "db"),
+					getMongoServicePayload("mongo-2", hostname, port, username, password, "inventory-2", "db")));
 
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		assertNotNull(getServiceInfo(serviceInfos, "mongo-1"));
@@ -31,38 +28,33 @@ public class CloudFoundryConnectorMongodbServiceTest extends AbstractCloudFoundr
 
     @Test
     public void mongoServiceCreationNoLabelNoTags() {
-        String[] versions = {"2.0", "2.2"};
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                        getMongoServicePayloadNoLabelNoTags(version, "mongo-1", hostname, port, username, password, "inventory-1", "db"),
-                        getMongoServicePayloadNoLabelNoTags(version, "mongo-2", hostname, port, username, password, "inventory-2", "db")));
-        }
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+					getMongoServicePayloadNoLabelNoTags("mongo-1", hostname, port, username, password, "inventory-1", "db"),
+					getMongoServicePayloadNoLabelNoTags("mongo-2", hostname, port, username, password, "inventory-2", "db")));
 
         List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
         assertNotNull(getServiceInfo(serviceInfos, "mongo-1"));
         assertNotNull(getServiceInfo(serviceInfos, "mongo-2"));
     }
     
-	private String getMongoServicePayload(String version, String serviceName,
-                                			 String hostname, int port,
-                                			 String username, String password, String db, String name) {
-        return getMongoServicePayload("test-mongodb-info.json", version, 
+	private String getMongoServicePayload(String serviceName, String hostname, int port,
+										  String username, String password, String db, String name) {
+        return getMongoServicePayload("test-mongodb-info.json",
                 serviceName, hostname, port, username, password, db, name);
 	}
 
-    private String getMongoServicePayloadNoLabelNoTags(String version, String serviceName,
+    private String getMongoServicePayloadNoLabelNoTags(String serviceName,
             String hostname, int port,
             String username, String password, String db, String name) {
-        return getMongoServicePayload("test-mongodb-info-no-label-no-tags.json", version, 
+        return getMongoServicePayload("test-mongodb-info-no-label-no-tags.json",
                 serviceName, hostname, port, username, password, db, name);
     }
 
-    private String getMongoServicePayload(String payloadFile, String version, String serviceName,
+    private String getMongoServicePayload(String payloadFile, String serviceName,
             String hostname, int port,
             String username, String password, String db, String name) {
         String payload = readTestDataFile(payloadFile);
-        payload = payload.replace("$version", version);
         payload = payload.replace("$serviceName", serviceName);
         payload = payload.replace("$hostname", hostname);
         payload = payload.replace("$port", Integer.toString(port));

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorMysqlServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorMysqlServiceTest.java
@@ -18,15 +18,12 @@ import org.springframework.cloud.service.common.MysqlServiceInfo;
 public class CloudFoundryConnectorMysqlServiceTest extends AbstractCloudFoundryConnectorRelationalServiceTest {
 	@Test
 	public void mysqlServiceCreation() {
-		String[] versions = {"5.1", "5.5"};
 		String name1 = "database-1";
 		String name2 = "database-2";
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-				.thenReturn(getServicesPayload(
-								getMysqlServicePayload(version, "mysql-1", hostname, port, username, password, name1),
-								getMysqlServicePayload(version, "mysql-2", hostname, port, username, password, name2)));
-		}
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+							getMysqlServicePayload("mysql-1", hostname, port, username, password, name1),
+							getMysqlServicePayload("mysql-2", hostname, port, username, password, name2)));
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		
 		MysqlServiceInfo info1 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-1");
@@ -39,15 +36,12 @@ public class CloudFoundryConnectorMysqlServiceTest extends AbstractCloudFoundryC
 
 	@Test
 	public void mysqlServiceCreationWithLabelNoTags() {
-		String[] versions = {"5.1", "5.5"};
 		String name1 = "database-1";
 		String name2 = "database-2";
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-				.thenReturn(getServicesPayload(
-								getMysqlServicePayloadWithLabelNoTags(version, "mysql-1", hostname, port, username, password, name1),
-								getMysqlServicePayloadWithLabelNoTags(version, "mysql-2", hostname, port, username, password, name2)));
-		}
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+							getMysqlServicePayloadWithLabelNoTags("mysql-1", hostname, port, username, password, name1),
+							getMysqlServicePayloadWithLabelNoTags("mysql-2", hostname, port, username, password, name2)));
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		
 		MysqlServiceInfo info1 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-1");
@@ -57,39 +51,33 @@ public class CloudFoundryConnectorMysqlServiceTest extends AbstractCloudFoundryC
 		assertEquals(getJdbcUrl("mysql", name1), info1.getJdbcUrl());
 		assertEquals(getJdbcUrl("mysql", name2), info2.getJdbcUrl());
 	}
-	
-    @Test
-    public void mysqlServiceCreationNoLabelNoTags() {
-        String[] versions = {"5.1", "5.5"};
-        String name1 = "database-1";
-        String name2 = "database-2";
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                                getMysqlServicePayloadNoLabelNoTags(version, "mysql-1", hostname, port, username, password, name1),
-                                getMysqlServicePayloadNoLabelNoTags(version, "mysql-2", hostname, port, username, password, name2)));
-        }
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        
-        MysqlServiceInfo info1 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-1");
-        MysqlServiceInfo info2 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-2");
-        assertNotNull(info1);
-        assertNotNull(info2);
-        assertEquals(getJdbcUrl("mysql", name1), info1.getJdbcUrl());
-        assertEquals(getJdbcUrl("mysql", name2), info2.getJdbcUrl());
-    }
 
-    @Test
+	@Test
+	public void mysqlServiceCreationNoLabelNoTags() {
+		String name1 = "database-1";
+		String name2 = "database-2";
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getMysqlServicePayloadNoLabelNoTags("mysql-1", hostname, port, username, password, name1),
+						getMysqlServicePayloadNoLabelNoTags("mysql-2", hostname, port, username, password, name2)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		MysqlServiceInfo info1 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-1");
+		MysqlServiceInfo info2 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-2");
+		assertNotNull(info1);
+		assertNotNull(info2);
+		assertEquals(getJdbcUrl("mysql", name1), info1.getJdbcUrl());
+		assertEquals(getJdbcUrl("mysql", name2), info2.getJdbcUrl());
+	}
+
+	@Test
 	public void mysqlServiceCreationWithLabelNoUri() {
-		String[] versions = {"5.1", "5.5"};
 		String name1 = "database-1";
 		String name2 = "database-2";
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-				.thenReturn(getServicesPayload(
-								getMysqlServicePayloadWithLabelNoUri(version, "mysql-1", hostname, port, username, password, name1),
-								getMysqlServicePayloadWithLabelNoUri(version, "mysql-2", hostname, port, username, password, name2)));
-		}
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+							getMysqlServicePayloadWithLabelNoUri("mysql-1", hostname, port, username, password, name1),
+							getMysqlServicePayloadWithLabelNoUri("mysql-2", hostname, port, username, password, name2)));
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		
 		MysqlServiceInfo info1 = (MysqlServiceInfo) getServiceInfo(serviceInfos, "mysql-1");
@@ -99,32 +87,32 @@ public class CloudFoundryConnectorMysqlServiceTest extends AbstractCloudFoundryC
 		assertEquals(getJdbcUrl("mysql", name1), info1.getJdbcUrl());
 		assertEquals(getJdbcUrl("mysql", name2), info2.getJdbcUrl());
 	}
-	
-	private String getMysqlServicePayload(String version, String serviceName,
-            String hostname, int port,
-            String user, String password, String name) {
-		return getRelationalPayload("test-mysql-info.json", version, serviceName,
+
+	private String getMysqlServicePayload(String serviceName,
+										  String hostname, int port,
+										  String user, String password, String name) {
+		return getRelationalPayload("test-mysql-info.json", serviceName,
 				hostname, port, user, password, name);
 	}
 
-	private String getMysqlServicePayloadWithLabelNoTags(String version, String serviceName,
-                           String hostname, int port,
-                           String user, String password, String name) {
-		return getRelationalPayload("test-mysql-info-with-label-no-tags.json", version, serviceName,
+	private String getMysqlServicePayloadWithLabelNoTags(String serviceName,
+														 String hostname, int port,
+														 String user, String password, String name) {
+		return getRelationalPayload("test-mysql-info-with-label-no-tags.json", serviceName,
 				hostname, port, user, password, name);
 	}
 
-    private String getMysqlServicePayloadNoLabelNoTags(String version, String serviceName,
-            String hostname, int port,
-            String user, String password, String name) {
-        return getRelationalPayload("test-mysql-info-no-label-no-tags.json", version, serviceName,
-                hostname, port, user, password, name);
-    }
-	
-	private String getMysqlServicePayloadWithLabelNoUri(String version, String serviceName,
-                          String hostname, int port,
-                          String user, String password, String name) {
-		return getRelationalPayload("test-mysql-info-with-label-no-uri.json", version, serviceName,
+	private String getMysqlServicePayloadNoLabelNoTags(String serviceName,
+													   String hostname, int port,
+													   String user, String password, String name) {
+		return getRelationalPayload("test-mysql-info-no-label-no-tags.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
+	private String getMysqlServicePayloadWithLabelNoUri(String serviceName,
+														String hostname, int port,
+														String user, String password, String name) {
+		return getRelationalPayload("test-mysql-info-with-label-no-uri.json", serviceName,
 				hostname, port, user, password, name);
 	}
 	

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorPostgresqlServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorPostgresqlServiceTest.java
@@ -11,65 +11,58 @@ import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.PostgresqlServiceInfo;
 
 /**
- * 
  * @author Ramnivas Laddad
- *
  */
 public class CloudFoundryConnectorPostgresqlServiceTest extends AbstractCloudFoundryConnectorRelationalServiceTest {
-    @Test
-    public void postgresqlServiceCreation() {
-        String[] versions = {"9.1", "9.2"};
-        String name1 = "database-1";
-        String name2 = "database-2";
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                                getPostgresqlServicePayload(version, "postgresql-1", hostname, port, username, password, name1),
-                                getPostgresqlServicePayload(version, "postgresql-2", hostname, port, username, password, name2)));
-        }
 
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        PostgresqlServiceInfo info1 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-1");
-        PostgresqlServiceInfo info2 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-2");
-        assertNotNull(info1);
-        assertNotNull(info2);
-        assertEquals(getJdbcUrl("postgres", name1), info1.getJdbcUrl());
-        assertEquals(getJdbcUrl("postgres", name2), info2.getJdbcUrl());
-    }
+	@Test
+	public void postgresqlServiceCreation() {
+		String name1 = "database-1";
+		String name2 = "database-2";
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getPostgresqlServicePayload("postgresql-1", hostname, port, username, password, name1),
+						getPostgresqlServicePayload("postgresql-2", hostname, port, username, password, name2)));
 
-    @Test
-    public void postgresqlServiceCreationNoLabelNoTags() {
-        String[] versions = {"9.1", "9.2"};
-        String name1 = "database-1";
-        String name2 = "database-2";
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                                getPostgresqlServicePayloadNoLabelNoTags(version, "postgresql-1", hostname, port, username, password, name1),
-                                getPostgresqlServicePayloadNoLabelNoTags(version, "postgresql-2", hostname, port, username, password, name2)));
-        }
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		PostgresqlServiceInfo info1 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-1");
+		PostgresqlServiceInfo info2 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-2");
+		assertNotNull(info1);
+		assertNotNull(info2);
+		assertEquals(getJdbcUrl("postgres", name1), info1.getJdbcUrl());
+		assertEquals(getJdbcUrl("postgres", name2), info2.getJdbcUrl());
+	}
 
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        PostgresqlServiceInfo info1 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-1");
-        PostgresqlServiceInfo info2 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-2");
-        assertNotNull(info1);
-        assertNotNull(info2);
-        assertEquals(getJdbcUrl("postgres", name1), info1.getJdbcUrl());
-        assertEquals(getJdbcUrl("postgres", name2), info2.getJdbcUrl());
-    }
-    
-    private String getPostgresqlServicePayload(String version, String serviceName,
-                                               String hostname, int port,
-                                               String user, String password, String name) {
-        return getRelationalPayload("test-postgresql-info.json", version, serviceName,
-                hostname, port, user, password, name);
-    }
+	@Test
+	public void postgresqlServiceCreationNoLabelNoTags() {
+		String name1 = "database-1";
+		String name2 = "database-2";
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getPostgresqlServicePayloadNoLabelNoTags("postgresql-1", hostname, port, username, password, name1),
+						getPostgresqlServicePayloadNoLabelNoTags("postgresql-2", hostname, port, username, password, name2)));
 
-    private String getPostgresqlServicePayloadNoLabelNoTags(String version, String serviceName,
-            String hostname, int port,
-            String user, String password, String name) {
-        return getRelationalPayload("test-postgresql-info-no-label-no-tags.json", version, serviceName,
-                hostname, port, user, password, name);
-}
-    
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		PostgresqlServiceInfo info1 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-1");
+		PostgresqlServiceInfo info2 = (PostgresqlServiceInfo) getServiceInfo(serviceInfos, "postgresql-2");
+		assertNotNull(info1);
+		assertNotNull(info2);
+		assertEquals(getJdbcUrl("postgres", name1), info1.getJdbcUrl());
+		assertEquals(getJdbcUrl("postgres", name2), info2.getJdbcUrl());
+	}
+
+	private String getPostgresqlServicePayload(String serviceName,
+											   String hostname, int port,
+											   String user, String password, String name) {
+		return getRelationalPayload("test-postgresql-info.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
+	private String getPostgresqlServicePayloadNoLabelNoTags(String serviceName,
+															String hostname, int port,
+															String user, String password, String name) {
+		return getRelationalPayload("test-postgresql-info-no-label-no-tags.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
 }

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorRedisServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorRedisServiceTest.java
@@ -16,57 +16,50 @@ import org.springframework.cloud.service.ServiceInfo;
 public class CloudFoundryConnectorRedisServiceTest extends AbstractCloudFoundryConnectorTest {
 	@Test
 	public void redisServiceCreation() {
-		String[] versions = {"2.0", "2.2"};
-		for (String version : versions) {
-			when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-				.thenReturn(getServicesPayload(
-						getRedisServicePayload(version, "redis-1", hostname, port, password, "redis-db"),
-						getRedisServicePayload(version, "redis-2", hostname, port, password, "redis-db")));
-		}
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(
+					getRedisServicePayload("redis-1", hostname, port, password, "redis-db"),
+					getRedisServicePayload("redis-2", hostname, port, password, "redis-db")));
 
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		assertNotNull(getServiceInfo(serviceInfos, "redis-1"));
 		assertNotNull(getServiceInfo(serviceInfos, "redis-2"));
 	}
 
-    @Test
-    public void redisServiceCreationNoLabelNoTags() {
-        String[] versions = {"2.0", "2.2"};
-        for (String version : versions) {
-            when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-                .thenReturn(getServicesPayload(
-                        getRedisServicePayloadNoLabelNoTags(version, "redis-1", hostname, port, password, "redis-db"),
-                        getRedisServicePayloadNoLabelNoTags(version, "redis-2", hostname, port, password, "redis-db")));
-        }
+	@Test
+	public void redisServiceCreationNoLabelNoTags() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getRedisServicePayloadNoLabelNoTags("redis-1", hostname, port, password, "redis-db"),
+						getRedisServicePayloadNoLabelNoTags("redis-2", hostname, port, password, "redis-db")));
 
-        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
-        assertNotNull(getServiceInfo(serviceInfos, "redis-1"));
-        assertNotNull(getServiceInfo(serviceInfos, "redis-2"));
-    }
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+		assertNotNull(getServiceInfo(serviceInfos, "redis-1"));
+		assertNotNull(getServiceInfo(serviceInfos, "redis-2"));
+	}
 
-    private String getRedisServicePayload(String version, String serviceName,
-            String hostname, int port,
-            String password, String name) {
-        return getRedisServicePayload("test-redis-info.json", version, serviceName, hostname, port, password, name);
-    }
-    
-    private String getRedisServicePayloadNoLabelNoTags(String version, String serviceName,
-            String hostname, int port,
-            String password, String name) {
-        return getRedisServicePayload("test-redis-info-no-label-no-tags.json", version, serviceName, hostname, port, password, name);
-    }
+	private String getRedisServicePayload(String serviceName,
+										  String hostname, int port,
+										  String password, String name) {
+		return getRedisServicePayload("test-redis-info.json", serviceName, hostname, port, password, name);
+	}
 
-    private String getRedisServicePayload(String payloadFile, String version, String serviceName,
-                                			 String hostname, int port,
-                                			 String password, String name) {
+	private String getRedisServicePayloadNoLabelNoTags(String serviceName,
+													   String hostname, int port,
+													   String password, String name) {
+		return getRedisServicePayload("test-redis-info-no-label-no-tags.json", serviceName, hostname, port, password, name);
+	}
+
+	private String getRedisServicePayload(String payloadFile, String serviceName,
+										  String hostname, int port,
+										  String password, String name) {
 		String payload = readTestDataFile(payloadFile);
-		payload = payload.replace("$version", version);
 		payload = payload.replace("$serviceName", serviceName);
 		payload = payload.replace("$hostname", hostname);
 		payload = payload.replace("$port", Integer.toString(port));
 		payload = payload.replace("$password", password);
 		payload = payload.replace("$name", name);
-		
+
 		return payload;
 	}
 }

--- a/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorSmtpServiceTest.java
+++ b/cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorSmtpServiceTest.java
@@ -20,7 +20,7 @@ public class CloudFoundryConnectorSmtpServiceTest extends AbstractCloudFoundryCo
 	@Test
 	public void smtpServiceCreation() {
 		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
-			.thenReturn(getServicesPayload(getSmtpServicePayload("n/a", "smtp-1", hostname, username, password)));
+			.thenReturn(getServicesPayload(getSmtpServicePayload("smtp-1", hostname, username, password)));
 
 		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
 		SmtpServiceInfo smptServiceInfo = (SmtpServiceInfo) getServiceInfo(serviceInfos, "smtp-1");
@@ -31,16 +31,14 @@ public class CloudFoundryConnectorSmtpServiceTest extends AbstractCloudFoundryCo
 		assertEquals(password, smptServiceInfo.getPassword());		
 	}
 
-	private String getSmtpServicePayload(String version, String serviceName,
-                                			String hostname, 
-                                			String user, String password) {
+	private String getSmtpServicePayload(String serviceName, String hostname,
+										 String user, String password) {
 		String payload = readTestDataFile("test-smtp-info.json");
-		payload = payload.replace("$version", version);
 		payload = payload.replace("$serviceName", serviceName);
 		payload = payload.replace("$hostname", hostname);
 		payload = payload.replace("$username", user);
 		payload = payload.replace("$password", password);
-		
+
 		return payload;
 	}
 }

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mongodb-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mongodb-info.json
@@ -1,6 +1,6 @@
 {
         "name": "$serviceName",
-        "label": "mongolab-$version",
+        "label": "mongolab",
         "plan": "free",
         "tags":["mongodb"],
         "credentials": {

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info-with-label-no-tags.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info-with-label-no-tags.json
@@ -1,6 +1,6 @@
 {
         "name": "$serviceName",
-        "label": "mysql-$version",
+        "label": "mysql",
         "tags": [],
         "plan": "free",
 		"credentials":{

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info-with-label-no-uri.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info-with-label-no-uri.json
@@ -1,6 +1,6 @@
 {
     "name": "$serviceName",
-    "label": "mysql-$version",
+    "label": "mysql",
 	"tags":[],
 	"plan":"100",
 	"credentials":{

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-mysql-info.json
@@ -1,6 +1,6 @@
 {
         "name": "$serviceName",
-        "label": "cleardb-$version",
+        "label": "cleardb",
         "tags": ["mysql"],
         "plan": "free",
 		"credentials":{

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-postgresql-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-postgresql-info.json
@@ -1,6 +1,6 @@
 {
         "name": "$serviceName",
-        "label": "elephantsql-$version",
+        "label": "elephantsql",
         "plan": "free",
         "tags": ["postgresql"],
         "credentials": {

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-rabbit-info-with-label-no-tags.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-rabbit-info-with-label-no-tags.json
@@ -1,6 +1,6 @@
 {
 	"name":"$serviceName",
-	"label":"rabbitmq-$version",
+	"label":"rabbitmq",
 	"tags":[],
 	"plan":"Standard",
 	"credentials":{

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-rabbit-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-rabbit-info.json
@@ -1,6 +1,6 @@
 {
 	"name":"$serviceName",
-	"label":"cloudamqp-$version",
+	"label":"cloudamqp",
 	"plan":"free",
 	"tags":["amqp","rabbitmq"],
 	"credentials":{

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-redis-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-redis-info.json
@@ -1,6 +1,6 @@
 {
         "name": "$serviceName",
-        "label": "rediscloud-$version",
+        "label": "rediscloud",
         "plan": "free",
         "tags":["redis","key-value"],
         "credentials": {

--- a/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smtp-info.json
+++ b/cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smtp-info.json
@@ -1,11 +1,11 @@
 {
         "name": "$serviceName",
-        "label": "sendgrid-$version",
+        "label": "sendgrid",
         "plan": "free",
         "tags":["smtp"],
         "credentials": {
         		"hostname" : "$hostname",
-        		"username" : "$username",        		
+        		"username" : "$username",
         		"password" : "$password"
         }
 }

--- a/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractUserProvidedServiceInfoCreatorTest.java
+++ b/cloudfoundry-ups-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractUserProvidedServiceInfoCreatorTest.java
@@ -3,14 +3,14 @@ package org.springframework.cloud.cloudfoundry;
 public class AbstractUserProvidedServiceInfoCreatorTest extends AbstractCloudFoundryConnectorRelationalServiceTest {
 	protected String getUserProvidedServicePayload(String serviceName, String hostname, int port,
 												   String user, String password, String name, String scheme) {
-		String payload = getRelationalPayload("test-ups-info.json", "", serviceName,
+		String payload = getRelationalPayload("test-ups-info.json", serviceName,
 				hostname, port, user, password, name);
 		return payload.replace("$scheme", scheme);
 	}
 
 	protected String getUserProvidedServicePayloadWithNoUri(String serviceName, String hostname, int port,
 															String user, String password, String name) {
-		return getRelationalPayload("test-ups-info-no-uri.json", "", serviceName,
+		return getRelationalPayload("test-ups-info-no-uri.json", serviceName,
 				hostname, port, user, password, name);
 	}
 }


### PR DESCRIPTION
Cloud Foundry no longer includes versions in service meta-data (as a separate field or appended to a label like `mysql-2.1` or `mysql-n/a`). Removed the version concept from all unit tests to simplify the tests.
