### PR TITLE
Made detection of host in RedisServiceInfoCreator more flexible.

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/AmqpServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/AmqpServiceInfoCreator.java
@@ -20,12 +20,9 @@ public class AmqpServiceInfoCreator extends CloudFoundryServiceInfoCreator<AmqpS
 		Map<String,Object> credentials = (Map<String, Object>) serviceData.get("credentials");
 		
 		String id = (String) serviceData.get("name");
-		
-		String uri = (String) credentials.get("uri");
-		if (uri == null || uri.length() == 0) {
-			uri = (String) credentials.get("url");
-		}
-			
+
+		String uri = getStringFromCredentials(credentials, "uri", "url");
+
 		return new AmqpServiceInfo(id, uri);
 	}
 

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreator.java
@@ -57,6 +57,15 @@ public abstract class CloudFoundryServiceInfoCreator<SI extends ServiceInfo> imp
 		return false;
 	}
 
+	protected String getStringFromCredentials(Map<String, Object> credentials, String... keys) {
+		for (String key : keys) {
+			if (credentials.containsKey(key)) {
+				return (String) credentials.get(key);
+			}
+		}
+		return null;
+	}
+
 	public String getUriScheme() {
 		return uriScheme;
 	}

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MongoServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/MongoServiceInfoCreator.java
@@ -22,7 +22,7 @@ public class MongoServiceInfoCreator extends CloudFoundryServiceInfoCreator<Mong
 
 		String id = (String) serviceData.get("name");
 
-		String uri = (String) ((credentials.get("uri") == null) ? credentials.get("url") : credentials.get("uri"));
+		String uri = getStringFromCredentials(credentials, "uri", "url");
 
 		return new MongoServiceInfo(id, uri);
 	}

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RedisServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RedisServiceInfoCreator.java
@@ -21,12 +21,10 @@ public class RedisServiceInfoCreator extends CloudFoundryServiceInfoCreator<Redi
 
 		String id = (String) serviceData.get("name");
 
-		String uri = (String) credentials.get("uri");
+		String uri = getStringFromCredentials(credentials, "uri", "url");
+
 		if (uri == null) {
-			uri = (String) credentials.get("url");
-		}
-		if (uri == null) {
-			String host = (String) credentials.get("hostname");
+			String host = getStringFromCredentials(credentials, "hostname", "host");
 			Integer port = Integer.parseInt(credentials.get("port").toString());
 			String password = (String) credentials.get("password");
 

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RelationalServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/RelationalServiceInfoCreator.java
@@ -24,20 +24,20 @@ public abstract class RelationalServiceInfoCreator<SI extends RelationalServiceI
 
 		String id = (String) serviceData.get("name");
 
-		String uri;
-		if (credentials.containsKey("uri")) {
-			uri = credentials.get("uri").toString();
-		} else {
-			String host = (String) credentials.get("host");
+		String uri = getStringFromCredentials(credentials, "uri", "url");
+
+		if (uri == null) {
+			String host = getStringFromCredentials(credentials, "hostname", "host");
 			int port = Integer.parseInt(credentials.get("port").toString()); // allows the port attribute to be quoted or plain
 
-			String username = (String) credentials.get("user");
+			String username = getStringFromCredentials(credentials, "user", "username");
 			String password = (String) credentials.get("password");
 
 			String database = (String) credentials.get("name");
 			
 			uri = new UriInfo(getUriScheme(), host, port, username, password, database).toString();
 		}
+
 		return createServiceInfo(id, uri);
 	}
 }

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/util/UriInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/util/UriInfo.java
@@ -84,7 +84,10 @@ public class UriInfo {
 			return new URI(scheme, userInfo, host, port, cleanedPath, query, null);
 		}
 		catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
+			String details = String.format("Error creating URI with components: " +
+							"scheme=%s, userInfo=%s, host=%s, port=%d, path=%s, query=%s",
+					scheme, userInfo, host, port, cleanedPath, query);
+			throw new IllegalArgumentException(details, e);
 		}
 	}
 


### PR DESCRIPTION
- Changed Cloud Foundry RedisServiceInfoCreator to accept either `host` or `hostname` in credentials. 
- Refactored other cases of multiple acceptable keys in credentials to be more consistent and readable. 
- Improved exception message when a URI cannot be propertly formed from parsed credentials. 
