### PR TITLE
Remove static hack

### DIFF
--- a/spring-cloud-core/src/main/java/org/springframework/cloud/util/EnvironmentAccessor.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/util/EnvironmentAccessor.java
@@ -3,30 +3,39 @@ package org.springframework.cloud.util;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.Properties;
 
 import org.springframework.cloud.CloudConnector;
 import org.springframework.cloud.CloudException;
 
 /**
  * Environment available to the deployed app.
- * 
+ *
  * The main purpose of this class is to allow unit-testing of {@link CloudConnector} implementations
  * that rely on environment
- * 
+ *
  * @author Ramnivas Laddad
  */
 public class EnvironmentAccessor {
-	
+
 	public Map<String, String> getEnv() {
 		return System.getenv();
 	}
-	
+
 	public String getEnvValue(String key) {
 		return System.getenv(key);
 	}
-	
-	public String getPropertyValue(String key) {
-		return System.getProperty(key);
+
+	public Properties getSystemProperties() {
+	    return System.getProperties();
+	}
+
+	public String getSystemProperty(String key) {
+		return getSystemProperty(key, null);
+	}
+
+	public String getSystemProperty(String key, String def) {
+	    return System.getProperty(key, def);
 	}
 
 	public String getHost() {

--- a/spring-cloud-localconfig-connector/build.gradle
+++ b/spring-cloud-localconfig-connector/build.gradle
@@ -2,5 +2,5 @@ description = 'Spring Cloud local-configuration connector'
 
 dependencies {
   compile project(':spring-cloud-core')
-  testCompile 'com.github.stefanbirkner:system-rules:1.5.0'
+  compile 'org.apache.commons:commons-lang3:3.3.2'
 }

--- a/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/PropertiesFileResolver.java
+++ b/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/PropertiesFileResolver.java
@@ -1,0 +1,150 @@
+package org.springframework.cloud.localconfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.text.StrLookup;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.springframework.cloud.util.EnvironmentAccessor;
+
+/**
+ * Helper class that handles finding and merging properties to be read by the connector.
+ *
+ * @author Christopher Smith
+ *
+ */
+class PropertiesFileResolver {
+
+    public static final String BOOTSTRAP_PROPERTIES_FILENAME = "spring-cloud-bootstrap.properties";
+
+    private static final Logger logger = Logger.getLogger(PropertiesFileResolver.class.getName());
+
+    private final EnvironmentAccessor env;
+
+    private final String classpathPropertiesFilename;
+
+    PropertiesFileResolver(final EnvironmentAccessor env, final String classpathPropertiesFilename) {
+        this.env = env;
+        this.classpathPropertiesFilename = classpathPropertiesFilename;
+    }
+
+    PropertiesFileResolver(final EnvironmentAccessor env) {
+        this(env, BOOTSTRAP_PROPERTIES_FILENAME);
+    }
+
+    PropertiesFileResolver() {
+        this(new EnvironmentAccessor());
+    }
+
+    /**
+     * Inspects the system properties for an entry named {@value LocalConfigConnector#PROPERTIES_FILE_PROPERTY} directing it to an
+     * external properties file.
+     *
+     * @return a {@code File} pointing to the external properties file, or {@code null} if the system property couldn't be read
+     */
+    File findCloudPropertiesFileFromSystem() {
+        String filename = null;
+
+        try {
+            filename = env.getSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY);
+        } catch (SecurityException e) {
+            logger.log(Level.WARNING, "SecurityManager prevented reading system property "
+                + LocalConfigConnector.PROPERTIES_FILE_PROPERTY, e);
+            return null;
+        }
+
+        if (filename == null) {
+            logger.fine("didn't find system property for a configuration file");
+            return null;
+        }
+
+        File file = new File(filename);
+        logger.info("found system property for a configuration file: " + file);
+        return file;
+    }
+
+    /**
+     * Looks for a resource named {@code filename} (usually {@value #BOOTSTRAP_PROPERTIES_FILENAME}) on the classpath. If present,
+     * it is loaded and
+     * inspected for a property named {@value LocalConfigConnector#PROPERTIES_FILE_PROPERTY}, which is interpolated from the system
+     * properties and returned.
+     *
+     * @return the filename derived from the classpath control file, or {@code null} if one couldn't be found
+     */
+    File findCloudPropertiesFileFromClasspath() {
+        // see if we have a spring-cloud.properties at all
+        InputStream in = getClass().getClassLoader().getResourceAsStream(classpathPropertiesFilename);
+        if (in == null) {
+            logger.info("no " + classpathPropertiesFilename
+                + " found on the classpath to direct us to an external properties file");
+            return null;
+        }
+
+        // load it as a properties file
+        Properties properties = new Properties();
+        try {
+            properties.load(in);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "found " + classpathPropertiesFilename
+                + " on the classpath but couldn't load it as a properties file", e);
+            return null;
+        }
+
+        // read the spring.cloud.propertiesFile property from it
+        String template = properties.getProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY);
+        if (template == null) {
+            logger.log(Level.SEVERE, "found properties file " + classpathPropertiesFilename
+                + " on the classpath, but it didn't contain a property named " + LocalConfigConnector.PROPERTIES_FILE_PROPERTY);
+            return null;
+        }
+
+        // if there's anything else, the client probably tried to put an app ID or other credentials there
+        if (properties.entrySet().size() > 1)
+            logger.warning("the properties file " + classpathPropertiesFilename + " contained properties besides "
+                + LocalConfigConnector.PROPERTIES_FILE_PROPERTY + "; ignoring");
+
+        logger.fine("substituting system properties into '" + template + "'");
+        File configFile = new File(new StrSubstitutor(systemPropertiesLookup(env)).replace(template));
+        logger.info("derived configuration file name: " + configFile);
+
+        return configFile;
+    }
+
+    File findCloudPropertiesFile() {
+        File file = findCloudPropertiesFileFromSystem();
+
+        if (file != null) {
+            logger.info("using configuration file from system properties");
+            return file;
+        }
+
+        file = findCloudPropertiesFileFromClasspath();
+
+        if (file != null)
+            logger.info("using configuration file derived from " + classpathPropertiesFilename);
+        else
+            logger.info("did not find any Spring Cloud configuration file");
+
+        return file;
+    }
+
+    /**
+     * Adapter from the {@link EnvironmentAccessor}'s system-property resolution to the {@code StrLookup} interface.
+     *
+     * @param env
+     *            the {@code EnvironmentAccessor} to use for the lookups
+     * @return a {@code StrLookup} view of the accessor's system properties
+     */
+    private StrLookup<String> systemPropertiesLookup(final EnvironmentAccessor env) {
+        return new StrLookup<String>() {
+            @Override
+            public String lookup(String key) {
+                return env.getSystemProperty(key);
+            }
+        };
+    }
+}

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/AbstractLocalConfigConnectorTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/AbstractLocalConfigConnectorTest.java
@@ -1,14 +1,10 @@
 package org.springframework.cloud.localconfig;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
-import java.util.Properties;
 
-import org.junit.After;
 import org.junit.Before;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.UriBasedServiceInfo;
@@ -17,7 +13,9 @@ public class AbstractLocalConfigConnectorTest {
 
     public static final String PROPERTIES_FILE = "localconfig.testuris.properties";
 
-    protected LocalConfigConnector connector = new LocalConfigConnector();
+    protected StubbedOpenFileLocalConfigConnector connector = new StubbedOpenFileLocalConfigConnector();
+
+    protected PassthroughEnvironmentAccessor env;
 
     protected static final String HOSTNAME = "10.20.30.40";
     protected static final int PORT = 1234;
@@ -26,14 +24,9 @@ public class AbstractLocalConfigConnectorTest {
 
     @Before
     public void init() throws IOException {
-        InputStream propertiesFile = getClass().getClassLoader().getResourceAsStream(PROPERTIES_FILE);
-        LocalConfigConnector.supplyProperties(propertiesFile);
-        assertTrue(connector.isInMatchingCloud());
-    }
-
-    @After
-    public void clearProperties() {
-        LocalConfigConnector.programmaticProperties = new Properties();
+        env = new PassthroughEnvironmentAccessor();
+        env.setSystemProperty("spring.cloud.baz", "inline!");
+        connector.setEnvironmentAccessor(env);
     }
 
     protected static ServiceInfo getServiceInfo(List<ServiceInfo> serviceInfos, String serviceId) {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/AbstractLocalConfigConnectorWithUrisTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/AbstractLocalConfigConnectorWithUrisTest.java
@@ -1,0 +1,20 @@
+package org.springframework.cloud.localconfig;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+
+import org.junit.Before;
+
+public class AbstractLocalConfigConnectorWithUrisTest extends AbstractLocalConfigConnectorTest {
+
+    public static String PROPERTY_FILE_WITH_URIS = "localconfig.testuris.properties";
+
+    @Before
+    public void useTestUris() {
+        InputStream testUrisProperties = getClass().getClassLoader().getResourceAsStream(PROPERTY_FILE_WITH_URIS);
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTY_FILE_WITH_URIS);
+        connector.setFileProvider(StubbedOpenFileLocalConfigConnector.fileContentsFromStream(PROPERTY_FILE_WITH_URIS, testUrisProperties));
+        assertTrue(connector.isInMatchingCloud());
+    }
+}

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorAmqpServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorAmqpServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.AmqpServiceInfo;
 
-public class LocalConfigConnectorAmqpServiceTest extends AbstractLocalConfigConnectorTest {
+public class LocalConfigConnectorAmqpServiceTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceCreation() {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorMongoServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorMongoServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.MongoServiceInfo;
 
-public class LocalConfigConnectorMongoServiceTest extends AbstractLocalConfigConnectorTest {
+public class LocalConfigConnectorMongoServiceTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceCreation() {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorMysqlServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorMysqlServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.MysqlServiceInfo;
 
-public class LocalConfigConnectorMysqlServiceTest extends AbstractLocalConfigConnectorTest {
+public class LocalConfigConnectorMysqlServiceTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceCreation() {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorPostgresqlServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorPostgresqlServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.PostgresqlServiceInfo;
 
-public class LocalConfigConnectorPostgresqlServiceTest extends AbstractLocalConfigConnectorTest {
+public class LocalConfigConnectorPostgresqlServiceTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceCreation() {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorRedisServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorRedisServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.RedisServiceInfo;
 
-public class LocalConfigConnectorRedisServiceTest extends AbstractLocalConfigConnectorTest {
+public class LocalConfigConnectorRedisServiceTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceCreation() {

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorTest.java
@@ -4,142 +4,41 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ClearSystemProperties;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
-import org.springframework.cloud.service.UriBasedServiceData;
 
-public class LocalConfigConnectorTest {
+public class LocalConfigConnectorTest extends AbstractLocalConfigConnectorTest {
 
-    static final Charset UTF_8 = Charset.forName("UTF-8");
-
-    public static final String APP_ID_1 = "appId1";
-    public static final String APP_ID_1_PROPERTY = LocalConfigConnector.APP_ID_PROPERTY + ": " + APP_ID_1;
-
-    public static final String APP_ID_2 = "appId2";
-    public static final String APP_ID_2_PROPERTY = LocalConfigConnector.APP_ID_PROPERTY + ": " + APP_ID_2;
+    public static final String APP_ID = "appId2";
+    public static final String APP_ID_PROPERTY = LocalConfigConnector.APP_ID_PROPERTY + ": " + APP_ID;
 
     public static final String PROPERTY_FILE_NAME = "localconfig.nonsense.properties";
     public static final String PROPERTY_FILE_PROPERTY = LocalConfigConnector.PROPERTIES_FILE_PROPERTY + ": " + PROPERTY_FILE_NAME;
 
-    public static class DetectAppIdTest {
-
-        private LocalConfigConnector connector;
-
-        @Before
-        public void setup() {
-            connector = new LocalConfigConnector();
-        }
-
-        @After
-        public void clearProperties() {
-            LocalConfigConnector.programmaticProperties = new Properties();
-        }
-
-        @Rule
-        public final ClearSystemProperties NO_APP_ID_PROPERTY = new ClearSystemProperties(LocalConfigConnector.APP_ID_PROPERTY);
-
-        @Test
-        public void testNoAppIdAnywhere() {
-            assertFalse(connector.isInMatchingCloud());
-        }
-
-        @Test
-        public void testProgrammaticAppId() throws IOException {
-            LocalConfigConnector.supplyProperties(new ByteArrayInputStream(APP_ID_1_PROPERTY.getBytes(UTF_8)));
-            assertTrue(connector.isInMatchingCloud());
-            assertEquals(APP_ID_1, connector.getApplicationInstanceInfo().getAppId());
-        }
-
-        @Test
-        public void testProgrammaticAndFileAppIds() throws IOException {
-            LocalConfigConnector.supplyProperties(new ByteArrayInputStream(APP_ID_1_PROPERTY.getBytes(UTF_8)));
-            LocalConfigConnector.supplyProperties(new ByteArrayInputStream(PROPERTY_FILE_PROPERTY.getBytes(UTF_8)));
-
-            LocalConfigConnector stubConnector = new LocalConfigConnector() {
-                @Override
-                InputStream openFile(String filename) throws IOException {
-                    assertEquals(PROPERTY_FILE_NAME, filename);
-                    return new ByteArrayInputStream(APP_ID_2_PROPERTY.getBytes(UTF_8));
-                };
-            };
-
-            assertTrue(stubConnector.isInMatchingCloud());
-            assertEquals(APP_ID_2, stubConnector.getApplicationInstanceInfo().getAppId());
-        }
-
-        @Test
-        public void testProgrammaticFilenamePlusSystemAppId() throws IOException {
-            LocalConfigConnector.supplyProperties(new ByteArrayInputStream(PROPERTY_FILE_PROPERTY.getBytes(UTF_8)));
-
-            LocalConfigConnector stubConnector = new LocalConfigConnector() {
-                @Override
-                InputStream openFile(String filename) throws IOException {
-                    assertEquals(PROPERTY_FILE_NAME, filename);
-                    return new ByteArrayInputStream(APP_ID_2_PROPERTY.getBytes(UTF_8));
-                };
-            };
-
-            System.setProperty(LocalConfigConnector.APP_ID_PROPERTY, "helloApp");
-            assertTrue(stubConnector.isInMatchingCloud());
-            assertEquals("helloApp", stubConnector.getApplicationInstanceInfo().getAppId());
-        }
-    }
-
-    private LocalConfigConnector connector;
-
-    InputStream propertiesFile;
-
-    @Before
-    public void setup() {
-        connector = new LocalConfigConnector();
-        propertiesFile = LocalConfigConnectorTest.class.getClassLoader().getResourceAsStream(PROPERTY_FILE_NAME);
-    }
-
-    @After
-    public void cleanup() throws IOException {
-        LocalConfigConnector.programmaticProperties = new Properties();
-        propertiesFile.close();
+    @Test
+    public void testNoAppIdAnywhere() {
+        assertFalse(connector.isInMatchingCloud());
     }
 
     @Test
-    public void testLoadFromFile() throws IOException {
-        LocalConfigConnector.supplyProperties(propertiesFile);
+    public void testAppIdInConfigFile() throws IOException {
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTY_FILE_NAME);
+
+        connector.setFileProvider(StubbedOpenFileLocalConfigConnector.fileContentsFromString(PROPERTY_FILE_NAME, APP_ID_PROPERTY));
 
         assertTrue(connector.isInMatchingCloud());
-        assertEquals("testApp", connector.getApplicationInstanceInfo().getAppId());
-
-        List<UriBasedServiceData> services = connector.getServicesData();
-        assertEquals(2, services.size());
-        for (UriBasedServiceData service : services)
-            if ("foo".equals(service.getKey()))
-                assertEquals("bar", service.getUri());
+        assertEquals(APP_ID, connector.getApplicationInstanceInfo().getAppId());
     }
 
-    @Rule
-    public ProvideSystemProperty BAZ_PROPERTY = new ProvideSystemProperty("spring.cloud.baz", "inline!");
-
     @Test
-    public void testLoadFromInputStreamWithOverride() throws IOException {
-        LocalConfigConnector.supplyProperties(propertiesFile);
+    public void testAppIdInFileAndSystem() throws IOException {
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTY_FILE_NAME);
+        env.setSystemProperty(LocalConfigConnector.APP_ID_PROPERTY, APP_ID);
+
+        connector.setFileProvider(StubbedOpenFileLocalConfigConnector.fileContentsFromString(PROPERTY_FILE_NAME, APP_ID_PROPERTY));
 
         assertTrue(connector.isInMatchingCloud());
-        assertEquals("testApp", connector.getApplicationInstanceInfo().getAppId());
-
-        List<UriBasedServiceData> services = connector.getServicesData();
-        assertEquals(2, services.size());
-        for(UriBasedServiceData service: services)
-            if("baz".equals(service.getKey()))
-                assertEquals("inline!", service.getUri());
+        assertEquals(APP_ID, connector.getApplicationInstanceInfo().getAppId());
     }
 }

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigServiceOverrideTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigServiceOverrideTest.java
@@ -6,22 +6,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.MongoServiceInfo;
 
-public class LocalConfigServiceOverrideTest extends AbstractLocalConfigConnectorTest {
-
-    @Rule
-    public final ProvideSystemProperty OVERRIDE_MYSQL =
-        new ProvideSystemProperty(
-            "spring.cloud.candygram",
-            "mongodb://youruser:yourpass@40.30.20.10:4321/dbname");
+public class LocalConfigServiceOverrideTest extends AbstractLocalConfigConnectorWithUrisTest {
 
     @Test
     public void serviceOverride() {
+        env.setSystemProperty("spring.cloud.candygram", "mongodb://youruser:yourpass@40.30.20.10:4321/dbname");
+
         List<ServiceInfo> services = connector.getServiceInfos();
         ServiceInfo service = getServiceInfo(services, "candygram");
         assertNotNull(service);
@@ -30,5 +24,4 @@ public class LocalConfigServiceOverrideTest extends AbstractLocalConfigConnector
         assertEquals("youruser", mongo.getUserName());
         assertEquals(4321, mongo.getPort());
     }
-
 }

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/PassthroughEnvironmentAccessor.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/PassthroughEnvironmentAccessor.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.localconfig;
+
+import java.util.Properties;
+
+import org.springframework.cloud.util.EnvironmentAccessor;
+
+class PassthroughEnvironmentAccessor extends EnvironmentAccessor {
+    private Properties systemProperties = new Properties(System.getProperties());
+
+    void clear() {
+        systemProperties.clear();
+    }
+
+    void setSystemProperty(String key, String value) {
+        systemProperties.setProperty(key, value);
+    }
+
+    @Override
+    public String getSystemProperty(String key, String defaultValue) {
+        return systemProperties.getProperty(key, defaultValue);
+    }
+
+    @Override
+    public Properties getSystemProperties() {
+        return systemProperties;
+    }
+}

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/PropertiesFileResolverTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/PropertiesFileResolverTest.java
@@ -1,0 +1,96 @@
+package org.springframework.cloud.localconfig;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertiesFileResolverTest {
+
+    private PassthroughEnvironmentAccessor env;
+
+    private PropertiesFileResolver resolver;
+
+    private String PROPERTIES_FILE_NAME = "/foo/bar.properties";
+
+    @Before
+    public void setDefaults() {
+        env = new PassthroughEnvironmentAccessor();
+        resolver = new PropertiesFileResolver(env);
+    }
+
+    @Test
+    public void testSecurityExceptionHandling() {
+        env = mock(PassthroughEnvironmentAccessor.class);
+        resolver = new PropertiesFileResolver(env);
+
+        when(env.getSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY)).thenThrow(new SecurityException());
+        assertNull(resolver.findCloudPropertiesFileFromSystem());
+        verify(env).getSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY);
+    }
+
+    @Test
+    public void testMissingSystemProperty() {
+        assertNull(resolver.findCloudPropertiesFileFromSystem());
+    }
+
+    @Test
+    public void testSystemProperty() {
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTIES_FILE_NAME);
+        assertEquals(PROPERTIES_FILE_NAME, resolver.findCloudPropertiesFileFromSystem().getPath());
+    }
+
+    @Test
+    public void testNoClasspathFile() {
+        resolver = new PropertiesFileResolver(env, "bazquux.properties");
+        assertNull(resolver.findCloudPropertiesFileFromClasspath());
+    }
+
+    @Test
+    public void testClasspathFileWithoutKey() {
+        resolver = new PropertiesFileResolver(env, "localconfig.testuris.properties");
+        assertNull(resolver.findCloudPropertiesFileFromClasspath());
+    }
+
+    @Test
+    public void testLiteral() {
+        resolver = new PropertiesFileResolver(env, "spring-cloud-literal.properties");
+        assertEquals(PROPERTIES_FILE_NAME,
+            resolver.findCloudPropertiesFileFromClasspath().getPath());
+    }
+
+    @Test
+    public void testTemplate() {
+        resolver = new PropertiesFileResolver(env, "spring-cloud-template.properties");
+        env.setSystemProperty("user.home", "/foo");
+        assertEquals(PROPERTIES_FILE_NAME,
+            resolver.findCloudPropertiesFileFromClasspath().getPath());
+    }
+
+    @Test
+    public void testFromSystem() {
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTIES_FILE_NAME);
+        assertEquals(PROPERTIES_FILE_NAME, resolver.findCloudPropertiesFile().getPath());
+    }
+
+    @Test
+    public void testFromClasspath() {
+        resolver = new PropertiesFileResolver(env, "spring-cloud-template.properties");
+        env.setSystemProperty("user.home", "/foo");
+        assertEquals(PROPERTIES_FILE_NAME,
+            resolver.findCloudPropertiesFile().getPath());
+    }
+
+    @Test
+    public void testNowhere() {
+        assertNull(resolver.findCloudPropertiesFile());
+    }
+
+    @Test
+    public void testPrecedence() {
+        env.setSystemProperty(LocalConfigConnector.PROPERTIES_FILE_PROPERTY, PROPERTIES_FILE_NAME);
+        resolver = new PropertiesFileResolver(env, "spring-cloud-literal.properties");
+        assertEquals(PROPERTIES_FILE_NAME, resolver.findCloudPropertiesFile().getPath());
+    }
+}

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/StubbedOpenFileLocalConfigConnector.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/StubbedOpenFileLocalConfigConnector.java
@@ -1,0 +1,65 @@
+package org.springframework.cloud.localconfig;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+/**
+ * Provides an easy way to stub the {@code openFile} method on the local connector.
+ *
+ * @author Christopher Smith
+ *
+ */
+class StubbedOpenFileLocalConfigConnector extends LocalConfigConnector {
+
+    static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private InputStreamProvider fileProvider;
+
+    @Override
+    InputStream openFile(File file) throws IOException {
+        return fileProvider.openFile(file);
+    }
+
+    public void setFileProvider(InputStreamProvider provider) {
+        this.fileProvider = provider;
+    }
+
+    interface InputStreamProvider {
+        InputStream openFile(File file) throws IOException;
+    }
+
+    /**
+     * Returns the supplied input stream. Used for reading out of the classpath for testing.
+     *
+     * @param filename
+     *            the filename we expect the connector to open
+     * @param contents
+     *            the contents to return
+     */
+    static InputStreamProvider fileContentsFromStream(final String expectedFilename, final InputStream stream) {
+        return new InputStreamProvider() {
+            @Override
+            public InputStream openFile(File file) throws IOException {
+                assertEquals(expectedFilename, file.getPath());
+                return stream;
+            }
+        };
+    }
+
+    /**
+     * Returns a stream view of the provided string.
+     *
+     * @param filename
+     *            the filename we expect the connector to open
+     * @param contents
+     *            the contents to return
+     */
+    static InputStreamProvider fileContentsFromString(final String expectedFilename, final String contents) {
+        return fileContentsFromStream(expectedFilename, new ByteArrayInputStream(contents.getBytes(UTF_8)));
+    }
+}

--- a/spring-cloud-localconfig-connector/src/test/resources/spring-cloud-literal.properties
+++ b/spring-cloud-localconfig-connector/src/test/resources/spring-cloud-literal.properties
@@ -1,0 +1,1 @@
+spring.cloud.propertiesFile=/foo/bar.properties

--- a/spring-cloud-localconfig-connector/src/test/resources/spring-cloud-template.properties
+++ b/spring-cloud-localconfig-connector/src/test/resources/spring-cloud-template.properties
@@ -1,0 +1,1 @@
+spring.cloud.propertiesFile=${user.home}/bar.properties


### PR DESCRIPTION
Removes the hacky static-setter model of preconfiguring the local connector and replaces with a pre-load check for a "symlink" file to the configuration properties file. As part of the rewrite, the test code replaced the direct static state twiddling with a stubbed `openFile` implementation to let an explicit file-open operation read out of the classpath instead. Documentation has been rewritten appropriately.

This PR supersedes #58, which was a preliminary cleanup.
