### PR TITLE
log at INFO if the local connector is available but no application ID is found for it

### DIFF
--- a/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/LocalConfigConnector.java
+++ b/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/LocalConfigConnector.java
@@ -76,7 +76,12 @@ public class LocalConfigConnector extends AbstractCloudConnector<UriBasedService
         if (fileProperties == null)
             readFileProperties();
 
-        return findProperty(APP_ID_PROPERTY) != null;
+        String appId = findProperty(APP_ID_PROPERTY);
+
+        if (appId == null)
+            logger.info("the property " + APP_ID_PROPERTY + " was not found in the system properties or configuration file");
+
+        return appId != null;
     }
 
     @Override


### PR DESCRIPTION
I managed to forget the activator property on my own connector on my first run. This adds a log message to explicitly note why the local connector isn't activating.
