### PR TITLE
nicer log message for when the properties file isn't found

### DIFF
--- a/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/LocalConfigConnector.java
+++ b/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/LocalConfigConnector.java
@@ -126,6 +126,11 @@ public class LocalConfigConnector extends AbstractCloudConnector<UriBasedService
             return;
         }
 
+        if (!propertiesFile.exists()) {
+            logger.info("properties file " + propertiesFile + " does not exist; probably running in a real cloud");
+            return;
+        }
+
         logger.info("loading service definitions from properties file " + propertiesFile);
 
         try {


### PR DESCRIPTION
Do an explicit `exists()` check before opening the file. We handle `ENOENT` just fine, but the log looks scary.
