### PR TITLE
GitHub issue #112: Allow authSource in the Mongo URI to be passed along

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
 
 	springAmqpVersion = "1.1.1.RELEASE"
 	springDataRedisVersion = "1.1.1.RELEASE"
-	springDataMongoVersion = "1.6.2.RELEASE"
+	springDataMongoVersion = "1.4.3.RELEASE"
 
 	jedisVersion = "2.1.0"
 
@@ -179,10 +179,10 @@ configure(rootProject) {
 
 ext {
 	matrix = [
-		"mongo13"        : [springDataMongoVersion: "1.3.5.RELEASE"],
-		"mongo14"        : [springDataMongoVersion: "1.4.2.RELEASE"],
+		"mongo14"        : [springDataMongoVersion: "1.4.3.RELEASE"],
 		"mongo15"        : [springDataMongoVersion: "1.5.5.RELEASE"],
 		"mongo16"        : [springDataMongoVersion: "1.6.2.RELEASE"],
+		"mongo17"        : [springDataMongoVersion: "1.7.0.RELEASE"],
 		"jedis22-redis11": [jedisVersion: "2.2.1", springDataRedisVersion: "1.1.1.RELEASE"],
 		"jedis23-redis12": [jedisVersion: "2.3.1", springDataRedisVersion: "1.2.1.RELEASE"],
 		"jedis23-redis13": [jedisVersion: "2.3.1", springDataRedisVersion: "1.3.0.RELEASE"],

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		maven { url 'http://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.5'
+		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
 		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
 	}
 }
@@ -18,7 +18,7 @@ ext {
 
 	springAmqpVersion = "1.1.1.RELEASE"
 	springDataRedisVersion = "1.1.1.RELEASE"
-	springDataMongoVersion = "1.2.4.RELEASE"
+	springDataMongoVersion = "1.6.2.RELEASE"
 
 	jedisVersion = "2.1.0"
 
@@ -181,7 +181,8 @@ ext {
 	matrix = [
 		"mongo13"        : [springDataMongoVersion: "1.3.5.RELEASE"],
 		"mongo14"        : [springDataMongoVersion: "1.4.2.RELEASE"],
-		"mongo15"        : [springDataMongoVersion: "1.5.0.RELEASE"],
+		"mongo15"        : [springDataMongoVersion: "1.5.5.RELEASE"],
+		"mongo16"        : [springDataMongoVersion: "1.6.2.RELEASE"],
 		"jedis22-redis11": [jedisVersion: "2.2.1", springDataRedisVersion: "1.1.1.RELEASE"],
 		"jedis23-redis12": [jedisVersion: "2.3.1", springDataRedisVersion: "1.2.1.RELEASE"],
 		"jedis23-redis13": [jedisVersion: "2.3.1", springDataRedisVersion: "1.3.0.RELEASE"],

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/MongoDbFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/MongoDbFactoryCreator.java
@@ -7,7 +7,15 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
+import com.mongodb.MongoClientOptions.Builder;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcern;
+
 import org.springframework.cloud.service.AbstractServiceConnectorCreator;
 import org.springframework.cloud.service.ServiceConnectorConfig;
 import org.springframework.cloud.service.ServiceConnectorCreationException;
@@ -17,13 +25,6 @@ import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
-
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientOptions.Builder;
-import com.mongodb.MongoException;
-import com.mongodb.ServerAddress;
-import com.mongodb.WriteConcern;
 
 /**
  * Simplified access to creating MongoDB service objects.
@@ -42,8 +43,10 @@ public class MongoDbFactoryCreator extends AbstractServiceConnectorCreator<Mongo
 			List<ServerAddress> serverAddressList = getServerAddresses(mongoClientURI);
 
 			MongoClient mongo = new MongoClient(serverAddressList, mongoOptionsToUse);
-			UserCredentials credentials = new UserCredentials(mongoClientURI.getUsername(), new String(mongoClientURI.getPassword()));
-			SimpleMongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(mongo, mongoClientURI.getDatabase(), credentials);
+			MongoCredential mongoCredential =  mongoClientURI.getCredentials();
+			UserCredentials credentials = new UserCredentials(mongoCredential.getUserName(), new String(mongoCredential.getPassword()));
+
+			SimpleMongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(mongo, mongoClientURI.getDatabase(), credentials, mongoCredential.getSource());
 
 			return configure(mongoDbFactory, (MongoDbFactoryConfig) config);
 		} catch (UnknownHostException e) {

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/MongoDbFactoryCloudConfigTestHelper.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/MongoDbFactoryCloudConfigTestHelper.java
@@ -3,11 +3,11 @@ package org.springframework.cloud.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
+
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import com.mongodb.Mongo;
-import com.mongodb.WriteConcern;
 
 /**
  * 
@@ -31,9 +31,9 @@ public class MongoDbFactoryCloudConfigTestHelper {
 			assertEquals(writeConcernW.intValue(), writeConcern.getW());
 		}
 		
-		Mongo mongo = (Mongo) ReflectionTestUtils.getField(connector, "mongo");
-		assertEquals(connectionsPerHost.intValue(), mongo.getMongoOptions().connectionsPerHost);
-		assertEquals(maxWaitTime.intValue(), mongo.getMongoOptions().maxWaitTime);
+		MongoClient mongoClient = (MongoClient) ReflectionTestUtils.getField(connector, "mongo");
+		assertEquals(connectionsPerHost.intValue(), mongoClient.getMongoClientOptions().getConnectionsPerHost());
+		assertEquals(maxWaitTime.intValue(), mongoClient.getMongoClientOptions().getMaxWaitTime());
 	}
 
 }


### PR DESCRIPTION
Also see comment in GitHub issue.
* Update Spring Data Mongo version (to 1.6.2) to support getting MongoCredentials class which has source property.
* Change MongoDbFactoryCreator to use different constructor for SimpleMongoDbFactory.
* Modify tests in MongoDbFactoryCloudConfigTestHelper that used deprecated functions based on version upgrade.
 Other item:
 * Update dependency version for propdeps-plugin to allow build to work in newer version of IntelliJ.