### PR TITLE
support for Spring Cloud properties with DB2 services i.e. cloud.services.{service-name}.connection.{property}

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/DB2ServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/DB2ServiceInfoCreator.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.service.common.DB2ServiceInfo;
 
 public class DB2ServiceInfoCreator extends RelationalServiceInfoCreator<DB2ServiceInfo> {
 	public DB2ServiceInfoCreator() {
-		super(new Tags(), DB2ServiceInfo.DB2_SCHEME);
+		super(new Tags("sqldb","dashDB","db2"), DB2ServiceInfo.DB2_SCHEME);
 	}
 
 	@Override

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/DB2ServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/DB2ServiceInfoCreator.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.DB2ServiceInfo;
+
+public class DB2ServiceInfoCreator extends RelationalServiceInfoCreator<DB2ServiceInfo> {
+	public DB2ServiceInfoCreator() {
+		super(new Tags(), DB2ServiceInfo.DB2_SCHEME);
+	}
+
+	@Override
+	public DB2ServiceInfo createServiceInfo(String id, String url) {
+		return new DB2ServiceInfo(id, url);
+	}
+}

--- a/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
+++ b/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
@@ -6,3 +6,4 @@ org.springframework.cloud.cloudfoundry.AmqpServiceInfoCreator
 org.springframework.cloud.cloudfoundry.MonitoringServiceInfoCreator
 org.springframework.cloud.cloudfoundry.SmtpServiceInfoCreator
 org.springframework.cloud.cloudfoundry.OracleServiceInfoCreator
+org.springframework.cloud.cloudfoundry.DB2ServiceInfoCreator

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorDB2ServiceTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorDB2ServiceTest.java
@@ -1,0 +1,69 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.junit.Test;
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.MysqlServiceInfo;
+import org.springframework.cloud.service.common.DB2ServiceInfo;
+import org.springframework.cloud.service.common.RelationalServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class CloudFoundryConnectorDB2ServiceTest extends AbstractUserProvidedServiceInfoCreatorTest {
+
+	private static final String INSTANCE_NAME = "database";
+	private static final String DB2_SCHEME = "db2:";
+	private static final String SERVICE_NAME = "db2-ups";
+
+	@Test
+	public void db2ServiceCreation() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME, DB2_SCHEME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		DB2ServiceInfo info = (DB2ServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertServiceFoundOfType(info, DB2ServiceInfo.class);
+		assertEquals(getDB2JdbcUrl(INSTANCE_NAME), info.getJdbcUrl());
+	}
+
+	@Test
+	public void db2ServiceCreationWithNoUri() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getUserProvidedServicePayloadWithNoUri(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		BaseServiceInfo info = (BaseServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertFalse(MysqlServiceInfo.class.isAssignableFrom(info.getClass()));  // service was not detected as MySQL
+		assertNotNull(info);
+	}
+
+	@Test
+	public void dServiceCreationWithJdbcUrl() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(getServicesPayload(
+						getDB2ServicePayloadWithJdbcurl(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME, DB2_SCHEME)));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		DB2ServiceInfo info = (DB2ServiceInfo) getServiceInfo(serviceInfos, SERVICE_NAME);
+		assertServiceFoundOfType(info, DB2ServiceInfo.class);
+		assertEquals(RelationalServiceInfo.JDBC_PREFIX + "db2:rawjdbcurl", info.getJdbcUrl());
+	}
+
+	protected String getDB2ServicePayloadWithJdbcurl(String serviceName, String hostname, int port,
+														String user, String password, String name, String scheme) {
+		String payload = getRelationalPayload("test-db2-info-jdbc-url.json", serviceName,
+				hostname, port, user, password, name);
+		return payload.replace("$scheme", scheme);
+	}
+
+	private String getDB2JdbcUrl(String name) {
+		return "jdbc:db2://" + hostname + ":" + port + "/" + name;
+	}
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-db2-info-jdbc-url.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-db2-info-jdbc-url.json
@@ -1,0 +1,7 @@
+{
+	"name": "$serviceName",
+	"credentials": {
+		"jdbcUrl": "jdbc:db2:rawjdbcurl",
+		"uri": "db2://$user:$password@$hostname:$port/$name"
+	}
+}

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
@@ -19,9 +19,9 @@ public class DB2ServiceInfo extends RelationalServiceInfo {
 			return getUriInfo().getUriString();
 		}
 		                    
-		return String.format("jdbc:%s://%s:%d/%s",
+		return String.format("jdbc:%s://%s:%d/%s:user=%s;password=%s;",
 				jdbcUrlDatabaseType, 
-				getHost(), getPort(), getPath());
+				getHost(), getPort(), getPath(), getUserName(), getPassword());
 	}
 
 }

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.service.common;
+
+import org.springframework.cloud.service.ServiceInfo;
+
+@ServiceInfo.ServiceLabel("db2")
+public class DB2ServiceInfo extends RelationalServiceInfo {
+
+    private static final String JDBC_URL_TYPE = "db2";
+
+    public static final String DB2_SCHEME = JDBC_URL_TYPE;
+
+	public DB2ServiceInfo(String id, String url) {
+		super(id, url, JDBC_URL_TYPE);
+	}
+
+	@Override
+	public String getJdbcUrl() {
+		if (getUriInfo().getUriString().startsWith(JDBC_PREFIX)) {
+			return getUriInfo().getUriString();
+		}
+		                    
+		return String.format("jdbc:%s://%s:%d/%s",
+				jdbcUrlDatabaseType, 
+				getHost(), getPort(), getPath());
+	}
+
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/DB2DataSourceCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/DB2DataSourceCreator.java
@@ -1,0 +1,13 @@
+package org.springframework.cloud.service.relational;
+
+import org.springframework.cloud.service.common.DB2ServiceInfo;;
+
+public class DB2DataSourceCreator extends DataSourceCreator<DB2ServiceInfo> {
+
+	private static final String[] DRIVERS = new String[]{"com.ibm.db2.jcc.DB2Driver"};
+	private static final String VALIDATION_QUERY = "VALUES 1";
+
+	public DB2DataSourceCreator() {
+		super("spring-cloud.db2.driver", DRIVERS, VALIDATION_QUERY);
+	}
+}

--- a/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -1,6 +1,7 @@
 org.springframework.cloud.service.relational.MysqlDataSourceCreator
 org.springframework.cloud.service.relational.PostgresqlDataSourceCreator
 org.springframework.cloud.service.relational.OracleDataSourceCreator
+org.springframework.cloud.service.relational.DB2DataSourceCreator
 org.springframework.cloud.service.keyval.RedisConnectionFactoryCreator
 org.springframework.cloud.service.document.MongoDbFactoryCreator
 org.springframework.cloud.service.messaging.RabbitConnectionFactoryCreator

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/relational/DB2DataSourceFactoryTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/relational/DB2DataSourceFactoryTest.java
@@ -1,0 +1,9 @@
+package org.springframework.cloud.service.relational;
+
+import org.springframework.cloud.service.common.DB2ServiceInfo;
+
+public class DB2DataSourceFactoryTest extends AbstractDataSourceFactoryTest<DB2ServiceInfo> {
+	public DB2ServiceInfo getTestServiceInfo(String id) {
+		return new DB2ServiceInfo(id, "db2://host:port/db:user=myuser;password=mypassword;");
+	}
+}

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/relational/DB2ServiceCreatorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/relational/DB2ServiceCreatorTest.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.service.relational;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cloud.service.common.DB2ServiceInfo;;
+
+public class DB2ServiceCreatorTest extends AbstractDataSourceCreatorTest<DB2DataSourceCreator, DB2ServiceInfo> {
+	@Mock private DB2ServiceInfo mockDB2ServiceInfo;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		// set a dummy JDBC driver since we can't yet include a real DB2 driver in the project due to licensing restrictions
+		System.setProperty("spring-cloud.db2.driver", "com.example.Driver");
+	}
+
+	@Override
+	public DB2ServiceInfo createServiceInfo() {
+		when(mockDB2ServiceInfo.getJdbcUrl()).thenReturn("db2://10.20.30.40:50000/database-123:user=myuser;password=mypassword;");
+		
+		return mockDB2ServiceInfo;
+	}
+
+	@Override
+	public String getDriverName() {
+		return "com.example.Driver";
+	}
+
+	@Override
+	public DB2DataSourceCreator getCreator() {
+		return new DB2DataSourceCreator();
+	}
+
+	@Override
+	public String getValidationQueryStart() {
+		return "VALUES 1";
+	}
+}


### PR DESCRIPTION
 Use-case : Pushing a Play framework generated .zip file to IBM Bluemix (CloudFoundry based) with the [java-buildpack](https://github.com/cloudfoundry/java-buildpack). The application has a bound DB2 service instance. The [app.conf](https://github.com/cloudfoundry-samples/zentasks-scala-cloudfoundry/blob/master/conf/application.conf) references the cloud.services.xxx.connection.uri. Need these Spring Cloud {cloud.services...) variables to be populated from the bound DB2 service.

Attached PR adds the DB2ServiceInfoCreator & registers it. Added CloudFoundryConnectorDB2ServiceTest and run it.  2 test cases fail with 'WARNING: No suitable service info creator found for service db2-ups Did you forget to add a ServiceInfoCreator?' , but i get the same failures even with Oracle, Postgres & MySQL tests. Screen shot attached
![pgcloudservices](https://cloud.githubusercontent.com/assets/3006502/7806258/62881fa6-039c-11e5-8d48-7cd635a1cdb3.png)

Also is there a way i can test on CloudFoundry(Bluemix) with the jars from my fork of the repo ?