### PR TITLE
Cassandra

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ ext {
 
 	jedisVersion = "2.1.0"
 
+
 	commonDbcpVersion = "1.4"
 	commonDbcp2Version = "2.0"
 
@@ -37,6 +38,8 @@ ext {
 	mockitoVersion = "1.9.5"
 	eurekaClientVersion = "1.1.135"
 	hadoopCommonVersion = "2.2.0"
+	cassandraDriverVersion = "2.1.6"
+	cassandraUnitVersion = "2.1.3.1"
 
 	javadocLinks = [
 		'http://docs.oracle.com/javase/7/docs/api/',

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreator.java
@@ -1,0 +1,34 @@
+package org.springframework.cloud.cloudfoundry;
+
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author  Vinicius Carvalho
+ */
+public class CassandraServiceInfoCreator extends CloudFoundryServiceInfoCreator<CassandraClusterServiceInfo>{
+
+    public CassandraServiceInfoCreator(){
+        super(new Tags("cassandra"));
+    }
+
+    public CassandraServiceInfoCreator(Tags tags, String... uriSchemes) {
+        super(tags);
+    }
+
+    @Override
+    public CassandraClusterServiceInfo createServiceInfo(Map<String, Object> stringObjectMap) {
+        Map<String,Object> credentials = (Map<String, Object>) stringObjectMap.get("credentials");
+        String id = (String) stringObjectMap.get("name");
+        String keyspace = getStringFromCredentials(credentials,"keyspace_name");
+        String username = getStringFromCredentials(credentials,"username");
+        String password = getStringFromCredentials(credentials,"password");
+        Integer thriftPort = (Integer) credentials.get("thrift_port");
+        Integer cqlPort = (Integer) credentials.get("cql_port");
+        List<String> nodeIps = (List<String>) credentials.get("node_ips");
+
+        return new CassandraClusterServiceInfo(id,nodeIps,username,password,keyspace,cqlPort);
+    }
+}

--- a/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
+++ b/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
@@ -6,3 +6,4 @@ org.springframework.cloud.cloudfoundry.AmqpServiceInfoCreator
 org.springframework.cloud.cloudfoundry.MonitoringServiceInfoCreator
 org.springframework.cloud.cloudfoundry.SmtpServiceInfoCreator
 org.springframework.cloud.cloudfoundry.OracleServiceInfoCreator
+org.springframework.cloud.cloudfoundry.CassandraServiceInfoCreator

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorCassandraServiceTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorCassandraServiceTest.java
@@ -1,6 +1,6 @@
 package org.springframework.cloud.cloudfoundry;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.common.CassandraClusterServiceInfo;

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorCassandraServiceTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorCassandraServiceTest.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.cloudfoundry;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CloudFoundryConnectorCassandraServiceTest extends AbstractCloudFoundryConnectorTest {
+
+    @Test
+    public void cloudfoundryConnection() throws Exception {
+        when(mockEnvironment.getEnvValue("VCAP_SERVICES")).thenReturn(
+                readTestDataFile("test-cassandra-info.json")
+        );
+        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+        assertServiceFoundOfType(serviceInfos, "time-series-db", CassandraClusterServiceInfo.class);
+        CassandraClusterServiceInfo serviceInfo = (CassandraClusterServiceInfo)serviceInfos.get(0);
+        Assert.assertEquals(2,serviceInfo.getNodes().size());
+
+    }
+
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-info.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-info.json
@@ -1,0 +1,21 @@
+{
+  "p-cassandra": [
+    {
+      "name": "time-series-db",
+      "label": "p-cassandra",
+      "tags": [
+        "pivotal",
+        "cassandra"
+      ],
+      "plan": "multi-tenant",
+      "credentials": {
+        "username" : "guybrush",
+        "password" : "threepwood",
+        "node_ips": ["10.20.30.40","10.20.30.41"],
+        "thrift_port": 9160,
+        "cql_port": 9042,
+        "keyspace_name": "weather"
+      }
+    }
+  ]
+}

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/CassandraClusterServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/CassandraClusterServiceInfo.java
@@ -1,0 +1,71 @@
+package org.springframework.cloud.service.common;
+
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.UriBasedServiceInfo;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author  Vinicius Carvalho
+ */
+@ServiceInfo.ServiceLabel("cassandra")
+public class CassandraClusterServiceInfo extends UriBasedServiceInfo {
+
+    public static final String CASSANDRA_SCHEME = "cassandra";
+    private final Integer cqlPort;
+    private String username;
+    private String password;
+    private String keyspace;
+    private List<String> nodes;
+
+    /**
+     * To keep compatibility with local config, we simply set the URI for the service using the first node in the cluster.
+     * The connector creator actually uses the full list of nodes when creating the cluster connection
+     * @param id
+     * @param nodes
+     * @param username
+     * @param password
+     * @param keyspace
+     * @param cqlPort
+     */
+    public CassandraClusterServiceInfo(String id, List<String> nodes, String username, String password, String keyspace, Integer cqlPort) {
+        super(id, CASSANDRA_SCHEME, nodes.get(0),cqlPort,username,password,keyspace);
+        this.nodes = nodes;
+        this.username = username;
+        this.password = password;
+        this.keyspace = keyspace;
+        this.cqlPort = cqlPort;
+    }
+
+    public CassandraClusterServiceInfo(String id, String uriString){
+        super(id,uriString);
+        this.nodes = Collections.singletonList(getUriInfo().getHost());
+        this.username = getUriInfo().getUserName();
+        this.password = getUriInfo().getPassword();
+        this.cqlPort = getUriInfo().getPort();
+        this.keyspace = getUriInfo().getPath();
+    }
+
+    @Override
+    public String getUserName() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    public String getKeyspace() {
+        return keyspace;
+    }
+
+    public List<String> getNodes() {
+        return nodes;
+    }
+    public Integer getCqlPort() {
+        return cqlPort;
+    }
+}

--- a/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/CassandraServiceInfoCreator.java
+++ b/spring-cloud-localconfig-connector/src/main/java/org/springframework/cloud/localconfig/CassandraServiceInfoCreator.java
@@ -1,0 +1,18 @@
+package org.springframework.cloud.localconfig;
+
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+
+/**
+ * @author  Vinicius Carvalho
+ */
+public class CassandraServiceInfoCreator extends LocalConfigServiceInfoCreator<CassandraClusterServiceInfo>{
+
+    public CassandraServiceInfoCreator(){
+        super(CassandraClusterServiceInfo.CASSANDRA_SCHEME);
+    }
+
+    @Override
+    public CassandraClusterServiceInfo createServiceInfo(String id, String uri) {
+        return new CassandraClusterServiceInfo(id,uri);
+    }
+}

--- a/spring-cloud-localconfig-connector/src/main/resources/META-INF/services/org.springframework.cloud.localconfig.LocalConfigServiceInfoCreator
+++ b/spring-cloud-localconfig-connector/src/main/resources/META-INF/services/org.springframework.cloud.localconfig.LocalConfigServiceInfoCreator
@@ -3,3 +3,4 @@ org.springframework.cloud.localconfig.MongoServiceInfoCreator
 org.springframework.cloud.localconfig.MysqlServiceInfoCreator
 org.springframework.cloud.localconfig.PostgresqlServiceInfoCreator
 org.springframework.cloud.localconfig.RedisServiceInfoCreator
+org.springframework.cloud.localconfig.CassandraServiceInfoCreator

--- a/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorCassandraServiceTest.java
+++ b/spring-cloud-localconfig-connector/src/test/java/org/springframework/cloud/localconfig/LocalConfigConnectorCassandraServiceTest.java
@@ -1,0 +1,28 @@
+package org.springframework.cloud.localconfig;
+
+import org.junit.Test;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author  Vinicius Carvalho
+ */
+public class LocalConfigConnectorCassandraServiceTest extends AbstractLocalConfigConnectorWithUrisTest{
+
+    @Test
+    public void serviceCreation() throws Exception{
+        List<ServiceInfo> services = connector.getServiceInfos();
+        ServiceInfo service = getServiceInfo(services, "cassandra");
+        assertNotNull(service);
+        assertTrue(service instanceof CassandraClusterServiceInfo);
+        assertUriParameters((CassandraClusterServiceInfo) service);
+
+        assertTrue(((CassandraClusterServiceInfo)service).getNodes().size() == 1);
+    }
+
+}

--- a/spring-cloud-localconfig-connector/src/test/resources/localconfig.testuris.properties
+++ b/spring-cloud-localconfig-connector/src/test/resources/localconfig.testuris.properties
@@ -4,3 +4,4 @@ spring.cloud.maria:		mysql://myuser:mypass@10.20.30.40:1234/dbname
 spring.cloud.candygram:	mongodb://myuser:mypass@10.20.30.40:1234/dbname
 spring.cloud.ingres:	postgres://myuser:mypass@10.20.30.40:1234/dbname
 spring.cloud.blue:		redis://myuser:mypass@10.20.30.40:1234/dbname
+spring.cloud.cassandra: cassandra://myuser:mypass@10.20.30.40:1234/dbname

--- a/spring-cloud-spring-service-connector/build.gradle
+++ b/spring-cloud-spring-service-connector/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     exclude(group: 'org.springframework', module: 'spring-context-support')
   }
   optional("redis.clients:jedis:$jedisVersion")
+  optional("com.datastax.cassandra:cassandra-driver-core:$cassandraDriverVersion")
+  optional("com.datastax.cassandra:cassandra-driver-mapping:$cassandraDriverVersion")
+  optional("org.cassandraunit:cassandra-unit:$cassandraUnitVersion")
 
   optional("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") {
     exclude(group: 'org.springframework', module: 'spring-beans')

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/xml/CloudCassandraSessionParser.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/xml/CloudCassandraSessionParser.java
@@ -1,0 +1,76 @@
+package org.springframework.cloud.config.xml;
+
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.policies.RetryPolicy;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.cloud.service.column.CassandraConnectorConfig;
+import org.springframework.cloud.service.column.CassandraSessionFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CloudCassandraSessionParser extends AbstractNestedElementCloudServiceFactoryParser {
+
+    final String ELEMENT_CASSANDRA_OPTIONS = "cassandra-options";
+    final String COMPRESSION_ATTRIBUTE = "compression";
+    final String RETRY_POLICY_ATTRIBUTE = "retry-policy";
+    final String LOAD_BALANCING_POLICY_ATTRIBUTE = "loadbalancing-policy";
+    final String SOCKET_OPTIONS_ATTRIBUTE = "socket-options";
+    final String RECONNECTION_POLICY_ATTRIBUTE ="reconnection-policy";
+
+    public CloudCassandraSessionParser() {
+        super(CassandraSessionFactory.class);
+    }
+
+    @Override
+    protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+        super.doParse(element, parserContext, builder);
+
+        Element optionsElement = DomUtils.getChildElementByTagName(element, ELEMENT_CASSANDRA_OPTIONS);
+
+        BeanDefinitionBuilder beanBuilder =
+                BeanDefinitionBuilder.genericBeanDefinition(CassandraConnectorConfig.class.getName());
+
+        if(optionsElement != null) {
+            String compressionString = optionsElement.getAttribute(COMPRESSION_ATTRIBUTE);
+            if (!StringUtils.isEmpty(compressionString)) {
+                ProtocolOptions.Compression compression = ProtocolOptions.Compression.valueOf(compressionString);
+                beanBuilder.addPropertyValue("compression", compression);
+            }
+
+            String retryPolicyString = optionsElement.getAttribute(RETRY_POLICY_ATTRIBUTE);
+            if (!StringUtils.isEmpty(retryPolicyString)) {
+                beanBuilder.addPropertyReference("retryPolicy", retryPolicyString);
+            }
+
+            String loadBalancingPolicyString = optionsElement.getAttribute(LOAD_BALANCING_POLICY_ATTRIBUTE);
+            if (!StringUtils.isEmpty(loadBalancingPolicyString)) {
+                beanBuilder.addPropertyReference("loadBalancingPolicy", loadBalancingPolicyString);
+            }
+
+            String socketOptionsString = optionsElement.getAttribute(SOCKET_OPTIONS_ATTRIBUTE);
+            if(!StringUtils.isEmpty(socketOptionsString)){
+                beanBuilder.addPropertyReference("socketOptions",socketOptionsString);
+            }
+
+            String reconnectionPolicyString = optionsElement.getAttribute(RECONNECTION_POLICY_ATTRIBUTE);
+            if(!StringUtils.isEmpty(reconnectionPolicyString)){
+                beanBuilder.addPropertyReference("reconnectionPolicy",reconnectionPolicyString);
+            }
+
+        }
+
+
+
+        builder.addConstructorArgValue(beanBuilder.getBeanDefinition());
+    }
+
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/xml/CloudNamespaceHandler.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/xml/CloudNamespaceHandler.java
@@ -25,6 +25,7 @@ public class CloudNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("redis-connection-factory", new CloudRedisConnectionFactoryParser());
 		registerBeanDefinitionParser("mongo-db-factory", new CloudMongoDbFactoryParser());
 		registerBeanDefinitionParser("data-source", new CloudDataSourceFactoryParser());
+		registerBeanDefinitionParser("cassandra-session-factory", new CloudCassandraSessionParser());
 
 		registerBeanDefinitionParser("connection-properties", new ConnectionPropertiesParser());
 

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectionFactoryConfig.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectionFactoryConfig.java
@@ -1,0 +1,7 @@
+package org.springframework.cloud.service.column;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CassandraConnectionFactoryConfig {
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectionFactoryConfig.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectionFactoryConfig.java
@@ -1,7 +1,0 @@
-package org.springframework.cloud.service.column;
-
-/**
- * @author Vinicius Carvalho
- */
-public class CassandraConnectionFactoryConfig {
-}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectorConfig.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectorConfig.java
@@ -17,12 +17,20 @@ public class CassandraConnectorConfig implements ServiceConnectorConfig{
     private RetryPolicy retryPolicy;
     private ReconnectionPolicy reconnectionPolicy;
     private LoadBalancingPolicy loadBalancingPolicy;
-    private PoolingOptions poolingOptions;
     private ProtocolOptions.Compression compression;
     private SocketOptions socketOptions;
-
     public RetryPolicy getRetryPolicy() {
         return retryPolicy;
+    }
+
+    public CassandraConnectorConfig(){}
+
+    public CassandraConnectorConfig(RetryPolicy retryPolicy, ReconnectionPolicy reconnectionPolicy, LoadBalancingPolicy loadBalancingPolicy, ProtocolOptions.Compression compression, SocketOptions socketOptions) {
+        this.retryPolicy = retryPolicy;
+        this.reconnectionPolicy = reconnectionPolicy;
+        this.loadBalancingPolicy = loadBalancingPolicy;
+        this.compression = compression;
+        this.socketOptions = socketOptions;
     }
 
     public void setRetryPolicy(RetryPolicy retryPolicy) {
@@ -43,14 +51,6 @@ public class CassandraConnectorConfig implements ServiceConnectorConfig{
 
     public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {
         this.loadBalancingPolicy = loadBalancingPolicy;
-    }
-
-    public PoolingOptions getPoolingOptions() {
-        return poolingOptions;
-    }
-
-    public void setPoolingOptions(PoolingOptions poolingOptions) {
-        this.poolingOptions = poolingOptions;
     }
 
     public ProtocolOptions.Compression getCompression() {

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectorConfig.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraConnectorConfig.java
@@ -1,0 +1,76 @@
+package org.springframework.cloud.service.column;
+
+import com.datastax.driver.core.AuthProvider;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CassandraConnectorConfig implements ServiceConnectorConfig{
+
+    private RetryPolicy retryPolicy;
+    private ReconnectionPolicy reconnectionPolicy;
+    private LoadBalancingPolicy loadBalancingPolicy;
+    private PoolingOptions poolingOptions;
+    private ProtocolOptions.Compression compression;
+    private SocketOptions socketOptions;
+
+    public RetryPolicy getRetryPolicy() {
+        return retryPolicy;
+    }
+
+    public void setRetryPolicy(RetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
+    }
+
+    public ReconnectionPolicy getReconnectionPolicy() {
+        return reconnectionPolicy;
+    }
+
+    public void setReconnectionPolicy(ReconnectionPolicy reconnectionPolicy) {
+        this.reconnectionPolicy = reconnectionPolicy;
+    }
+
+    public LoadBalancingPolicy getLoadBalancingPolicy() {
+        return loadBalancingPolicy;
+    }
+
+    public void setLoadBalancingPolicy(LoadBalancingPolicy loadBalancingPolicy) {
+        this.loadBalancingPolicy = loadBalancingPolicy;
+    }
+
+    public PoolingOptions getPoolingOptions() {
+        return poolingOptions;
+    }
+
+    public void setPoolingOptions(PoolingOptions poolingOptions) {
+        this.poolingOptions = poolingOptions;
+    }
+
+    public ProtocolOptions.Compression getCompression() {
+        return compression;
+    }
+
+    public void setCompression(ProtocolOptions.Compression compression) {
+        this.compression = compression;
+    }
+
+    public SocketOptions getSocketOptions() {
+        return socketOptions;
+    }
+
+    public void setSocketOptions(SocketOptions socketOptions) {
+        this.socketOptions = socketOptions;
+    }
+
+
+
+
+
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionCreator.java
@@ -1,0 +1,60 @@
+package org.springframework.cloud.service.column;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.springframework.cloud.service.AbstractServiceConnectorCreator;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CassandraSessionCreator extends AbstractServiceConnectorCreator<Session, CassandraClusterServiceInfo> {
+
+
+    @Override
+    public Session create(CassandraClusterServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {
+        Cluster cluster = createClusterConnection(serviceInfo,(CassandraConnectorConfig)serviceConnectorConfig);
+        Session session = (StringUtils.isEmpty(serviceInfo.getKeyspace())) ? cluster.connect() : cluster.connect(serviceInfo.getKeyspace());
+
+        return session;
+    }
+
+    private Cluster createClusterConnection(CassandraClusterServiceInfo serviceInfo, CassandraConnectorConfig config){
+        Cluster.Builder builder = Cluster.builder();
+
+        builder.addContactPoints(serviceInfo.getNodes().toArray(new String[]{})).withPort(serviceInfo.getCqlPort());
+
+        if(!StringUtils.isEmpty(serviceInfo.getUserName())){
+            builder.withCredentials(serviceInfo.getUserName(),serviceInfo.getPassword());
+        }
+
+        if(config != null && config.getCompression() != null){
+            builder.withCompression(config.getCompression());
+        }
+
+        if(config != null && config.getLoadBalancingPolicy() != null){
+            builder.withLoadBalancingPolicy(config.getLoadBalancingPolicy());
+        }
+
+        if(config != null && config.getPoolingOptions() != null){
+            builder.withPoolingOptions(config.getPoolingOptions());
+        }
+
+        if(config != null && config.getReconnectionPolicy() != null){
+            builder.withReconnectionPolicy(config.getReconnectionPolicy());
+        }
+
+        if(config != null && config.getRetryPolicy() != null){
+            builder.withRetryPolicy(config.getRetryPolicy());
+        }
+
+
+        return builder.build();
+    }
+
+
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionCreator.java
@@ -18,12 +18,13 @@ public class CassandraSessionCreator extends AbstractServiceConnectorCreator<Ses
     @Override
     public Session create(CassandraClusterServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {
         Cluster cluster = createClusterConnection(serviceInfo,(CassandraConnectorConfig)serviceConnectorConfig);
-        Session session = (StringUtils.isEmpty(serviceInfo.getKeyspace())) ? cluster.connect() : cluster.connect(serviceInfo.getKeyspace());
+
+        Session session = (StringUtils.isEmpty(serviceInfo.getKeyspace())) ? cluster.newSession() : cluster.connect(serviceInfo.getKeyspace());
 
         return session;
     }
 
-    private Cluster createClusterConnection(CassandraClusterServiceInfo serviceInfo, CassandraConnectorConfig config){
+    protected Cluster createClusterConnection(CassandraClusterServiceInfo serviceInfo, CassandraConnectorConfig config){
         Cluster.Builder builder = Cluster.builder();
 
         builder.addContactPoints(serviceInfo.getNodes().toArray(new String[]{})).withPort(serviceInfo.getCqlPort());
@@ -40,8 +41,8 @@ public class CassandraSessionCreator extends AbstractServiceConnectorCreator<Ses
             builder.withLoadBalancingPolicy(config.getLoadBalancingPolicy());
         }
 
-        if(config != null && config.getPoolingOptions() != null){
-            builder.withPoolingOptions(config.getPoolingOptions());
+        if(config != null && config.getSocketOptions() != null){
+            builder.withSocketOptions(config.getSocketOptions());
         }
 
         if(config != null && config.getReconnectionPolicy() != null){

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionFactory.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/column/CassandraSessionFactory.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.service.column;
+
+import com.datastax.driver.core.Session;
+import org.springframework.cloud.service.AbstractCloudServiceConnectorFactory;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CassandraSessionFactory extends AbstractCloudServiceConnectorFactory<Session> {
+    public CassandraSessionFactory(String serviceId,ServiceConnectorConfig serviceConnectorConfiguration) {
+        super(serviceId, Session.class, serviceConnectorConfiguration);
+    }
+}

--- a/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -5,3 +5,4 @@ org.springframework.cloud.service.keyval.RedisConnectionFactoryCreator
 org.springframework.cloud.service.document.MongoDbFactoryCreator
 org.springframework.cloud.service.messaging.RabbitConnectionFactoryCreator
 org.springframework.cloud.service.smtp.MailSenderCreator
+org.springframework.cloud.service.column.CassandraSessionCreator

--- a/spring-cloud-spring-service-connector/src/main/resources/org/springframework/cloud/config/xml/spring-cloud.xsd
+++ b/spring-cloud-spring-service-connector/src/main/resources/org/springframework/cloud/config/xml/spring-cloud.xsd
@@ -165,6 +165,8 @@
 		</xsd:complexType>
 	</xsd:element>
 
+
+
 	<xsd:element name="properties">
 		<xsd:annotation>
 			<xsd:documentation source="org.cloudfoundry.runtime.env.CloudPropertiesFactoryBean"><![CDATA[
@@ -319,5 +321,118 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
+
+
+	<xsd:element name="cassandra-session-factory">
+		<xsd:annotation>
+			<xsd:documentation>
+				Locates a cassandra service
+			</xsd:documentation>
+		</xsd:annotation>
+
+		<xsd:complexType>
+
+			<xsd:sequence>
+				<xsd:element name="cassandra-options" type="cassandraOptionsType" minOccurs="0" maxOccurs="1"/>
+
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The id for this Cassandra Session instance.
+						If not provided, the service name will be used as a fallback.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="service-name" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The name of the cassandra service.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+
+		</xsd:complexType>
+
+	</xsd:element>
+
+	<xsd:complexType name="cassandraOptionsType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Element defining optional Cassandra configuration settings.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attributeGroup ref="compressionOptions"/>
+		<xsd:attribute type="xsd:string" name="reconnection-policy">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A reference to a com.datastax.driver.core.policies.ReconnectionPolicy implementation
+	          		]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="com.datastax.driver.core.policies.ReconnectionPolicy"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+
+		</xsd:attribute>
+		<xsd:attribute type="xsd:string" name="loadbalancing-policy">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A reference to a com.datastax.driver.core.policies.LoadBalancingPolicy implementation
+	          		]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="com.datastax.driver.core.policies.LoadBalancingPolicy"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+
+		</xsd:attribute>
+		<xsd:attribute type="xsd:string" name="socket-options">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A reference to a com.datastax.driver.core.SocketOptions Object
+	          		]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="com.datastax.driver.core.SocketOptions"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+
+		</xsd:attribute>
+		<xsd:attribute type="xsd:string" name="retry-policy">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A reference to a com.datastax.driver.core.policies.RetryPolicy Object
+	          		]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="com.datastax.driver.core.policies.RetryPolicy"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+
+		</xsd:attribute>
+	</xsd:complexType>
+
+
+	<xsd:attributeGroup name="compressionOptions">
+		<xsd:attribute name="compression">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					com.datastax.driver.core.policies.RetryPolicy to be used
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="NONE" />
+					<xsd:enumeration value="LZ4" />
+					<xsd:enumeration value="SNAPPY" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
 
 </xsd:schema>

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/StubCloudConnectorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/StubCloudConnectorTest.java
@@ -2,14 +2,12 @@ package org.springframework.cloud;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.cloud.service.ServiceInfo;
-import org.springframework.cloud.service.common.MongoServiceInfo;
-import org.springframework.cloud.service.common.MysqlServiceInfo;
-import org.springframework.cloud.service.common.PostgresqlServiceInfo;
-import org.springframework.cloud.service.common.AmqpServiceInfo;
-import org.springframework.cloud.service.common.RedisServiceInfo;
+import org.springframework.cloud.service.common.*;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.util.Collections;
 
 /**
  * Base class for close-to-integration tests that use a stub {@link CloudConnector} to avoid the need for a real cloud environment.
@@ -73,5 +71,10 @@ abstract public class StubCloudConnectorTest {
 	
 	protected RedisServiceInfo createRedisService(String id) {
 		return new RedisServiceInfo(id, "host", 1234, "password");
+	}
+
+	//We can't use keyspaces to test cassandra as it expects to connect to the cluster. Other test scenarios use mocks to test it
+	protected CassandraClusterServiceInfo createCassandraService(String id){
+		return new CassandraClusterServiceInfo(id, Collections.singletonList("10.20.30.40"),"username","password","",9042);
 	}
 }

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/CassandraSessionXmlConfigTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/CassandraSessionXmlConfigTest.java
@@ -1,0 +1,47 @@
+package org.springframework.cloud.config.xml;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class CassandraSessionXmlConfigTest extends AbstractServiceXmlConfigTest<Session> {
+
+    @Test
+    public void cassandraSessionWithConfiguration() throws Exception{
+        ApplicationContext testContext = getTestApplicationContext("cloud-cassandra-with-config.xml", createService("my-service"));
+        Session session = testContext.getBean("cassandra-full-config", getConnectorType());
+        Assert.assertNotNull(session.getCluster().getConfiguration().getSocketOptions());
+        Assert.assertEquals(15000,session.getCluster().getConfiguration().getSocketOptions().getConnectTimeoutMillis());
+        Assert.assertTrue(DefaultRetryPolicy.class.isAssignableFrom(session.getCluster().getConfiguration().getPolicies().getRetryPolicy().getClass()));
+        Assert.assertTrue(RoundRobinPolicy.class.isAssignableFrom(session.getCluster().getConfiguration().getPolicies().getLoadBalancingPolicy().getClass()));
+        Assert.assertTrue(ConstantReconnectionPolicy.class.isAssignableFrom(session.getCluster().getConfiguration().getPolicies().getReconnectionPolicy().getClass()));
+    }
+
+    @Override
+    protected String getWithServiceIdContextFileName() {
+        return "cloud-cassandra-with-service-id.xml";
+    }
+
+    @Override
+    protected String getWithoutServiceIdContextFileName() {
+        return "cloud-cassandra-without-service-id.xml";
+    }
+
+    @Override
+    protected ServiceInfo createService(String id) {
+        return createCassandraService(id);
+    }
+
+    @Override
+    protected Class<Session> getConnectorType() {
+        return Session.class;
+    }
+}

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/CloudAllServicesTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/CloudAllServicesTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNotNull;
 
 import javax.sql.DataSource;
 
+import com.datastax.driver.core.Session;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.beans.factory.BeanCreationException;
@@ -36,7 +37,8 @@ public class CloudAllServicesTest extends StubCloudConnectorTest {
 																   createPostgresqlService("postDb"),
 																   createMongoService("mongoDb"),
 																   createRedisService("redisDb"),
-																   createRabbitService("rabbit"));
+																   createRabbitService("rabbit"),
+				  													createCassandraService("cassandra"));
 		
 		assertNotNull("Getting service by id", testContext.getBean("mysqlDb"));
 		assertNotNull("Getting service by id and type", testContext.getBean("mysqlDb", DataSource.class));		
@@ -51,7 +53,11 @@ public class CloudAllServicesTest extends StubCloudConnectorTest {
 		assertNotNull("Getting service by id and type", testContext.getBean("redisDb", RedisConnectionFactory.class));		
 
 		assertNotNull("Getting service by id", testContext.getBean("rabbit"));
-		assertNotNull("Getting service by id and type", testContext.getBean("rabbit", ConnectionFactory.class));		
+		assertNotNull("Getting service by id and type", testContext.getBean("rabbit", ConnectionFactory.class));
+
+		assertNotNull("Getting service by id", testContext.getBean("cassandra"));
+		assertNotNull("Getting service by id and type", testContext.getBean("cassandra", Session.class));
+
 	}
 	
 }

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/cassandra/CassandraSessionConnectorCreatorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/cassandra/CassandraSessionConnectorCreatorTest.java
@@ -1,0 +1,69 @@
+package org.springframework.cloud.service.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.io.util.FileUtils;
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.CQLDataSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.cloud.service.column.CassandraSessionCreator;
+import org.springframework.cloud.service.common.CassandraClusterServiceInfo;
+
+import java.io.File;
+import java.util.Collections;
+
+/**
+ * Created by vcarvalho on 6/10/15.
+ */
+public class CassandraSessionConnectorCreatorTest {
+
+    @Test
+    public void withoutKeyspace() throws Exception{
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+
+
+        CassandraClusterServiceInfo info = new CassandraClusterServiceInfo("local", Collections.singletonList("127.0.0.1"),null,null,null,9142);
+        CassandraSessionCreator creator = new CassandraSessionCreator();
+        Session session = creator.create(info, null);
+
+        Assert.assertNull(session.getLoggedKeyspace());
+
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    }
+
+    @Test
+    public void withKeyspace() throws Exception {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+
+        CassandraClusterServiceInfo info = new CassandraClusterServiceInfo("local", Collections.singletonList("localhost"),null,null,"mykeyspace",9142);
+        CQLDataSet dataSet = new ClassPathCQLDataSet("org/springframework.cloud/service.cassandra/cassandra-dataset.cql",info.getKeyspace());
+        Session globalSession = Cluster.builder().addContactPoints(info.getNodes().get(0)).withPort(info.getCqlPort()).build().connect();
+        CQLDataLoader dataLoader = new CQLDataLoader(globalSession);
+        dataLoader.load(dataSet);
+
+
+        CassandraSessionCreator creator = new CassandraSessionCreator();
+        Session session = creator.create(info, null);
+
+        Assert.assertEquals("mykeyspace", session.getLoggedKeyspace());
+
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+
+    }
+
+
+    @AfterClass
+    public static void cleanEmbeddedDirs() throws Exception{
+
+        File dirFile = new File("target");
+        if (dirFile.exists()) {
+            FileUtils.deleteRecursive(new File("target"));
+        }
+    }
+
+
+}

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/cassandra/CassandraSessionConnectorCreatorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/cassandra/CassandraSessionConnectorCreatorTest.java
@@ -23,7 +23,6 @@ public class CassandraSessionConnectorCreatorTest {
 
     @Test
     public void withoutKeyspace() throws Exception{
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 
 
         CassandraClusterServiceInfo info = new CassandraClusterServiceInfo("local", Collections.singletonList("127.0.0.1"),null,null,null,9142);
@@ -32,7 +31,6 @@ public class CassandraSessionConnectorCreatorTest {
 
         Assert.assertNull(session.getLoggedKeyspace());
 
-        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
     }
 
     @Test

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework.cloud/service.cassandra/cassandra-dataset.cql
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework.cloud/service.cassandra/cassandra-dataset.cql
@@ -1,0 +1,4 @@
+CREATE TABLE myTable(
+    id varchar,
+    value varchar,
+    PRIMARY KEY(id));

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-all-services.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-all-services.xml
@@ -10,5 +10,5 @@
 	<cloud:mongo-db-factory service-name="mongoDb"/>
 	<cloud:redis-connection-factory service-name="redisDb"/>
 	<cloud:rabbit-connection-factory service-name="rabbit"/>
-	
+	<cloud:cassandra-session-factory service-name="cassandra"/>
 </beans>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cloud="http://www.springframework.org/schema/cloud"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+
+    <bean id="loadBalancingPolicy" class="com.datastax.driver.core.policies.RoundRobinPolicy"/>
+    <bean id="reconnectionPolicy" class="com.datastax.driver.core.policies.ConstantReconnectionPolicy">
+        <constructor-arg index="0" value="2000"/>
+    </bean>
+    <bean id="retryPolicy" class="com.datastax.driver.core.policies.DefaultRetryPolicy"/>
+    <bean id="socketOptions" class="com.datastax.driver.core.SocketOptions">
+        <property name="keepAlive" value="true"/>
+        <property name="connectTimeoutMillis" value="15000"/>
+    </bean>
+
+    <cloud:cassandra-session-factory id="cassandra-full-config" service-name="my-service" >
+        <cloud:cassandra-options compression="SNAPPY" retry-policy="retryPolicy"
+                                 loadbalancing-policy="loadBalancingPolicy" reconnection-policy="reconnectionPolicy"
+                                 socket-options="socketOptions"/>
+    </cloud:cassandra-session-factory>
+</beans>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-service-id.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cloud="http://www.springframework.org/schema/cloud"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+
+
+    <cloud:cassandra-session-factory service-name="my-service"/>
+
+
+</beans>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-without-service-id.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cloud="http://www.springframework.org/schema/cloud"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+
+
+    <cloud:cassandra-session-factory/>
+
+
+</beans>


### PR DESCRIPTION
Adding cassandra as a cloud connector. Both Java and XML are supported.

The only caveat of the PR is how to test a scenario within cassandra where we need to specify the keyspace (this is actually the default behavior with CloudFoundry Service Broker)

The ClusterBuilder from datastax needs to connect to the remote cluster in order to do that.

I'm attaching one test case where cassandra-unit is used. It's very lightweight from my tests, but if this is a major issue, we can try using mock and reflection api to override some private methods on the cluster builder.