### PR TITLE
added ServiceProperty annotation for jdbcurl

### DIFF
--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/DB2ServiceInfo.java
@@ -9,10 +9,11 @@ public class DB2ServiceInfo extends RelationalServiceInfo {
 
     public static final String DB2_SCHEME = JDBC_URL_TYPE;
 
-	public DB2ServiceInfo(String id, String url) {
+    public DB2ServiceInfo(String id, String url) {
 		super(id, url, JDBC_URL_TYPE);
 	}
 
+	@ServiceProperty(category = "connection")
 	@Override
 	public String getJdbcUrl() {
 		if (getUriInfo().getUriString().startsWith(JDBC_PREFIX)) {
@@ -23,5 +24,5 @@ public class DB2ServiceInfo extends RelationalServiceInfo {
 				jdbcUrlDatabaseType, 
 				getHost(), getPort(), getPath(), getUserName(), getPassword());
 	}
-
+	
 }


### PR DESCRIPTION
@scottfrederick i actually ran a play app to IBM Bluemix with the spring snapshot jars and found that the getJdbcUrl method of DB2ServiceInfo was not getting invoked but rather the one in the base class (RelationalServiceInfo) was getting invoked. I had to add the @ServiceProperty annotation of get it invoked. So this pull request. thanks much