### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
-		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	}
 }
 
@@ -68,8 +68,12 @@ subprojects {
 			maven { url "https://repo.spring.io/libs-snapshot" }
 		}
 
-		dependencies {
-			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+		dependencyManagement {
+			springIoTestRuntime {
+				imports {
+					mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Cloud Connectors's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in the version of Spring Cloud Connectors that will be in Spring IO Platform 2.0. That's currently 1.1.x, but it looks as if it might make sense for that to change to 1.2.0? If you have any questions, please let me know.