### PR TITLE
CF connector to check lattice environment

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
@@ -34,7 +34,8 @@ public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Obj
 
 	@Override
 	public boolean isInMatchingCloud() {
-		return environment.getEnvValue("VCAP_APPLICATION") != null;
+		return environment.getEnvValue("VCAP_APPLICATION") != null &&
+				environment.getEnvValue("PROCESS_GUID") == null;
 	}
 	
 	@Override

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
@@ -35,7 +35,7 @@ public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Obj
 	@Override
 	public boolean isInMatchingCloud() {
 		return environment.getEnvValue("VCAP_APPLICATION") != null &&
-				environment.getEnvValue("PROCESS_GUID") == null;
+				environment.getEnvValue("VCAP_APP_HOST") != null;
 	}
 	
 	@Override


### PR DESCRIPTION
 - If the CF connector is available in `lattice` environment (in case multiple connectors added as runtime dependency), both the CF connector and lattice connector would match the cloud. This is because both CF and Lattice environments have `VCAP_APPLICATION` env variable when using buildpack support.
   - To fix this, CF connector can only be active if `PROCESS_GUID` env variable isn't present