### PR TITLE
Update DB2DataSourceCreator.java

### DIFF
--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/DB2DataSourceCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/DB2DataSourceCreator.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.service.common.DB2ServiceInfo;;
 public class DB2DataSourceCreator extends DataSourceCreator<DB2ServiceInfo> {
 
 	private static final String[] DRIVERS = new String[]{"com.ibm.db2.jcc.DB2Driver"};
-	private static final String VALIDATION_QUERY = "VALUES 1";
+	private static final String VALIDATION_QUERY = "select 1 from sysibm.sysdummy1";
 
 	public DB2DataSourceCreator() {
 		super("spring-cloud.db2.driver", DRIVERS, VALIDATION_QUERY);


### PR DESCRIPTION
The validation query is incorrect for DB2.  It works for derby but not DB2.    The query "select 1 from sysibm.sysdummy1" works for both.
