### PR TITLE
Add support for lettuce Redis client configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext {
 	springDataMongoVersion = "1.4.3.RELEASE"
 
 	jedisVersion = "2.1.0"
+	lettuceVersion = "3.4.3.Final"
 
 	commonDbcpVersion = "1.4"
 	commonDbcp2Version = "2.0"

--- a/spring-cloud-heroku-connector/src/main/java/org/springframework/cloud/heroku/HerokuConnector.java
+++ b/spring-cloud-heroku-connector/src/main/java/org/springframework/cloud/heroku/HerokuConnector.java
@@ -18,7 +18,7 @@ import org.springframework.cloud.util.EnvironmentAccessor;
 
 /**
  * Implementation of CloudConnector for Heroku
- * <p/>
+ *
  * Currently support Postgres (default provided), Mysql (Cleardb), MongoDb (MongoLab, MongoHQ, MongoSoup),
  * Redis (RedisToGo, RedisCloud, OpenRedis, RedisGreen), and AMQP (CloudAmqp).
  *

--- a/spring-cloud-spring-service-connector/build.gradle
+++ b/spring-cloud-spring-service-connector/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     exclude(group: 'org.springframework', module: 'spring-context-support')
   }
   optional("redis.clients:jedis:$jedisVersion")
+  optional("biz.paluch.redis:lettuce:$lettuceVersion")
 
   optional("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") {
     exclude(group: 'org.springframework', module: 'spring-beans')

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/CloudScanHelper.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/config/CloudScanHelper.java
@@ -98,7 +98,7 @@ public class CloudScanHelper {
 									  "factoryBeanObjectType", serviceFactory.getObjectType());
 			registry.registerBeanDefinition(serviceInfo.getId(), definitionBuilder.getBeanDefinition());
 		} catch (Exception ex) {
-			logger.warning("Unable to create service for " + serviceInfo.getId() + " during service scanning. Skiping.");
+			logger.warning("Unable to create service for " + serviceInfo.getId() + " during service scanning. Skipping.");
 		}
 	}
 

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisConnectionFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisConnectionFactoryCreator.java
@@ -9,39 +9,62 @@ import org.springframework.cloud.service.ServiceConnectorCreationException;
 import org.springframework.cloud.service.common.RedisServiceInfo;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 /**
  * Simplified access to creating Redis service objects.
+ * Supports Jedis and lettuce Redis clients.
  *
  * @author Ramnivas Laddad
  * @author Jennifer Hickey
  * @author Thomas Risberg
- *
+ * @author Mark Paluch
  */
 public class RedisConnectionFactoryCreator extends AbstractServiceConnectorCreator<RedisConnectionFactory, RedisServiceInfo> {
 
-	private static final String REDIS_CLIENT_CLASS_NAME = "redis.clients.jedis.Jedis";
-
-	RedisConnectionFactoryConfigurer configurer = new RedisConnectionFactoryConfigurer();
+	private static final String JEDIS_CLASS_NAME = "redis.clients.jedis.Jedis";
+	private static final String LETTUCE_CLASS_NAME = "com.lambdaworks.redis.RedisClient";
 
 	@Override
 	public RedisConnectionFactory create(RedisServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {
-		if (hasClass(REDIS_CLIENT_CLASS_NAME)) {
+
+		if (hasClass(JEDIS_CLASS_NAME)) {
+
+			RedisConnectionFactoryConfigurer configurer = new RedisConnectionFactoryConfigurer();
+
 			JedisConnectionFactory connectionFactory = new JedisConnectionFactory();
 			connectionFactory.setHostName(serviceInfo.getHost());
 			connectionFactory.setPort(serviceInfo.getPort());
 			connectionFactory.setPassword(serviceInfo.getPassword());
+
 			if (serviceConnectorConfig instanceof RedisConnectionFactoryConfig) {
 				configurer.configure(connectionFactory, (RedisConnectionFactoryConfig) serviceConnectorConfig);
 			} else {
 				configurer.configure(connectionFactory, (PooledServiceConnectorConfig) serviceConnectorConfig);
 			}
+
 			connectionFactory.afterPropertiesSet();
 			return connectionFactory;
-		} else {
-			throw new ServiceConnectorCreationException("Failed to create cloud Redis connection factory for "
-					+ serviceInfo.getId() + " service.  Jedis client implementation class ("
-					+ REDIS_CLIENT_CLASS_NAME + ") not found");
+		}
+		else if (hasClass(LETTUCE_CLASS_NAME)) {
+
+			RedisLettuceConnectionFactoryConfigurer configurer = new RedisLettuceConnectionFactoryConfigurer();
+
+			LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
+			connectionFactory.setHostName(serviceInfo.getHost());
+			connectionFactory.setPort(serviceInfo.getPort());
+			connectionFactory.setPassword(serviceInfo.getPassword());
+
+			configurer.configure(connectionFactory, (RedisConnectionFactoryConfig) serviceConnectorConfig);
+
+			connectionFactory.afterPropertiesSet();
+			return connectionFactory;
+		}
+		else {
+			throw new ServiceConnectorCreationException(String.format("Failed to create cloud Redis connection factory " +
+					"for %s service. No client implementation classes "
+					+ " of jedis or lettuce clients implementation (%s, %s) not found", serviceInfo.getId(),
+					JEDIS_CLASS_NAME, LETTUCE_CLASS_NAME));
 		}
 	}
 }

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisLettuceConnectionFactoryConfigurer.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisLettuceConnectionFactoryConfigurer.java
@@ -1,0 +1,28 @@
+package org.springframework.cloud.service.keyval;
+
+import org.springframework.cloud.service.*;
+
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+/**
+ * 
+ * @author Mark Paluch
+ */
+public class RedisLettuceConnectionFactoryConfigurer implements ServiceConnectorConfigurer<LettuceConnectionFactory, RedisConnectionFactoryConfig> {
+	private MapServiceConnectionConfigurer<LettuceConnectionFactory, MapServiceConnectorConfig> mapServiceConnectionConfigurer =
+			new MapServiceConnectionConfigurer<LettuceConnectionFactory, MapServiceConnectorConfig>();
+
+	@Override
+	public LettuceConnectionFactory configure(LettuceConnectionFactory connectionFactory, RedisConnectionFactoryConfig config) {
+		if (config != null) {
+			configureConnection(connectionFactory, config);
+		}
+		return connectionFactory;
+	}
+
+	private void configureConnection(LettuceConnectionFactory connectionFactory, RedisConnectionFactoryConfig config) {
+		if (config.getConnectionProperties() != null) {
+			mapServiceConnectionConfigurer.configure(connectionFactory, config.getConnectionProperties());
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for [mp911de/lettuce](https://gthub.com/mp911de/github) as alternative Redis client. RedisConnectionFactory supports jedis and lettuce, depending on the available classes.