### PR TITLE
Don't hardcode Spring AMQP's default channel cache size

### DIFF
--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/RabbitConnectionFactoryCloudConfigTestHelper.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/RabbitConnectionFactoryCloudConfigTestHelper.java
@@ -26,7 +26,8 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  */
 public class RabbitConnectionFactoryCloudConfigTestHelper {
-	public static final int DEFAULT_CHANNEL_CACHE_SIZE = 1;
+	public static final Integer DEFAULT_CHANNEL_CACHE_SIZE =
+			(Integer) ReflectionTestUtils.getField(new org.springframework.amqp.rabbit.connection.CachingConnectionFactory(), "channelCacheSize");
 
 	private final static Integer DEFAULT_FACTORY_TIMEOUT =
 			(Integer) ReflectionTestUtils.getField(new com.rabbitmq.client.ConnectionFactory(), "connectionTimeout");


### PR DESCRIPTION
The default channel cache size was changed as a result of
https://jira.spring.io/browse/AMQP-606. This means that Cloud
Connectors tests are broken when run against Spring AMQP 1.6 (as
the IO Platform compatibility builds do).

Similar to, bed0d7f8, this commit updates the test helper to retrieve
the actual default via reflection, rather than hardcoding it.