### PR TITLE
Update tests to also be compatible with Mongo 3.2.x

### DIFF
--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/MongoDbFactoryCloudConfigTestHelper.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/MongoDbFactoryCloudConfigTestHelper.java
@@ -3,11 +3,11 @@ package org.springframework.cloud.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.mongodb.MongoClient;
-import com.mongodb.WriteConcern;
-
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.mongodb.MongoClient;
+import com.mongodb.WriteConcern;
 
 /**
  * 
@@ -16,7 +16,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  */
 public class MongoDbFactoryCloudConfigTestHelper {
 	
-	public static void assertConfigProperties(MongoDbFactory connector, Integer writeConcernW, Integer connectionsPerHost, Integer maxWaitTime) {
+	public static void assertConfigProperties(MongoDbFactory connector, String writeConcern, Integer connectionsPerHost, Integer maxWaitTime) {
 		if (connectionsPerHost == null) {
 			connectionsPerHost = 100; // default
 		}
@@ -25,11 +25,7 @@ public class MongoDbFactoryCloudConfigTestHelper {
 		}
 		assertNotNull(connector);
 
-		WriteConcern writeConcern = (WriteConcern) ReflectionTestUtils.getField(connector, "writeConcern");
-		if (writeConcernW != null) {
-			assertNotNull(writeConcern);
-			assertEquals(writeConcernW.intValue(), writeConcern.getW());
-		}
+		assertEquals(ReflectionTestUtils.getField(connector,  "writeConcern"), writeConcern == null ? null : WriteConcern.valueOf(writeConcern));
 		
 		MongoClient mongoClient = (MongoClient) ReflectionTestUtils.getField(connector, "mongo");
 		assertEquals(connectionsPerHost.intValue(), mongoClient.getMongoClientOptions().getConnectionsPerHost());

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/java/MongoDbFactoryJavaConfigTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/java/MongoDbFactoryJavaConfigTest.java
@@ -32,7 +32,7 @@ public class MongoDbFactoryJavaConfigTest extends AbstractServiceJavaConfigTest<
 				getTestApplicationContext(MongoDbFactoryConfigWithServiceConfig.class, createService("my-service"));
 		
 		MongoDbFactory connector = testContext.getBean("connectionPerHost50_MaxWait200_WriteConcernNone", getConnectorType());
-		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, -1, 50, 200);
+		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, "none", 50, 200);
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public class MongoDbFactoryJavaConfigTest extends AbstractServiceJavaConfigTest<
 				getTestApplicationContext(MongoDbFactoryConfigWithServiceConfig.class, createService("my-service"));
 		
 		MongoDbFactory connector = testContext.getBean("connectionPerHost50_MaxWait200_WriteConcernSafe", getConnectorType());
-		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, 1, 50, 200);
+		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, "safe", 50, 200);
 	}
 
 	@Test

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/MongoDbFactoryXmlConfigTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/config/xml/MongoDbFactoryXmlConfigTest.java
@@ -35,7 +35,7 @@ public class MongoDbFactoryXmlConfigTest extends AbstractServiceXmlConfigTest<Mo
 		ApplicationContext testContext = getTestApplicationContext("cloud-mongo-with-config.xml", createService("my-service"));
 		
 		MongoDbFactory connector = testContext.getBean("service-connectionPerHost50-maxWait200-WriteConcernNone", getConnectorType());
-		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, -1, 50, 200);
+		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, "none", 50, 200);
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class MongoDbFactoryXmlConfigTest extends AbstractServiceXmlConfigTest<Mo
 		ApplicationContext testContext = getTestApplicationContext("cloud-mongo-with-config.xml", createService("my-service"));
 		
 		MongoDbFactory connector = testContext.getBean("service-maxWait200-connectionPerHost50-WriteConcernSafe", getConnectorType());
-		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, 1, 50, 200);
+		MongoDbFactoryCloudConfigTestHelper.assertConfigProperties(connector, "safe", 50, 200);
 	}
 
 	@Test


### PR DESCRIPTION
The IO 2.1 compatibility build tests Spring Cloud Connectors against Spring Data MongoDB 1.9.x and Mongo Java Driver 3.2.x. This results in a number of test failures due to changes in the behaviour of Mongo's driver. I believe the changes only affect the tests, i.e. no runtime changes are warranted, but I'm far from an expert on Mongo or Spring Cloud Connectors.  The failures that this pull request fixes can be reproduced by running the following command:

```
./gradlew clean springIoCheck -PJDK8_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home -PplatformVersion=2.1.0.BUILD-SNAPSHOT --continue
```

Alternatively, adding an explicit dependency on Mongo Java Driver 3.2.x should also be sufficient.