### PR TITLE
Existing Code throws a NullPointerException

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
@@ -70,11 +70,13 @@ public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Obj
 		if (servicesString == null || servicesString.length() == 0) {
 			rawServices = new HashMap<String, List<Map<String,Object>>>();
 		}
-		try {
-			rawServices = objectMapper.readValue(servicesString, Map.class);
-		} catch (Exception e) {
-			throw new CloudException(e);
-		} 
+		else {
+			try {
+				rawServices = objectMapper.readValue(servicesString, Map.class);
+			} catch (Exception e) {
+				throw new CloudException(e);
+			} 
+		}
 		
 		List<Map<String,Object>> flatServices = new ArrayList<Map<String,Object>>();
 		for (Map.Entry<String, List<Map<String,Object>>> entry : rawServices.entrySet()) {


### PR DESCRIPTION
Caused by: java.lang.NullPointerException
	at java.io.StringReader.<init>(StringReader.java:50) ~[?:1.8.0_66]
	at org.springframework.cloud.cloudfoundry.com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:835) ~[spring-cloud-cloudfoundry-connector-1.2.3.RELEASE.jar:?]
	at org.springframework.cloud.cloudfoundry.com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2098) ~[spring-cloud-cloudfoundry-connector-1.2.3.RELEASE.jar:?]
	at org.springframework.cloud.cloudfoundry.TestCloudFoundryConnector.getServicesData(TestCloudFoundryConnector.java:68) ~[test-classes/:?]
	at org.springframework.cloud.AbstractCloudConnector.getServiceInfos(AbstractCloudConnector.java:39) ~[spring-cloud-core-1.2.3.RELEASE.jar:?]
	at org.springframework.cloud.Cloud.getServiceInfos(Cloud.java:89) ~[spring-cloud-core-1.2.3.RELEASE.jar:?]
	at org.springframework.cloud.Cloud.getServiceInfo(Cloud.java:76) ~[spring-cloud-core-1.2.3.RELEASE.jar:?]