### PR TITLE
Oracle cloud connector document update

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
@@ -108,7 +108,7 @@ The connector will check for:
 The connector will check for:
 
 * `uri` or `uris` using the scheme `oracle`
-* `jdbcUrl` field in `credentials` using the scheme `oracle`
+* `jdbcUrl` field in `credentials`
 * `oracleUri`, `oracleuri`, `oracleUrl`, or `oracleurl` fields in `credentials`
 
 ==== PostgreSQL

--- a/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
@@ -108,7 +108,7 @@ The connector will check for:
 The connector will check for:
 
 * `uri` or `uris` using the scheme `oracle`
-* `jdbcUrl` field in `credentials`
+* `jdbcUrl` field in `credentials` using the subprotocol `oracle` in the JDBC URL
 * `oracleUri`, `oracleuri`, `oracleUrl`, or `oracleurl` fields in `credentials`
 
 ==== PostgreSQL


### PR DESCRIPTION
Document update. If jdbcUrl is specified, it alone is enough for service detection, no oracle scheme  needs to be specified.