### PR TITLE
Upgrade Data autoconfiguration for Spring Data 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _site
 /bin
 .idea
 *.iml
+classes

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
 	apply plugin: 'propdeps-eclipse'
 	apply plugin: "org.asciidoctor.gradle.asciidoctor"
 
-	asciidoctor { 
+	asciidoctor {
 		sourceDir = new File("docs/src/main/asciidoc")
 		outputDir = new File("docs/target/generated-docs")
 		options = [
@@ -100,6 +100,7 @@ subprojects {
 
 	repositories {
 		mavenCentral()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url "https://repo.spring.io/libs-milestone" }
 		maven { url "https://repo.spring.io/libs-snapshot" }
 	}
@@ -174,7 +175,7 @@ ext {
 	matrix = [
 			"driver34-mongo20"  : [mongoDriverVersion: "3.4.2", springDataMongoVersion: "2.0.0.BUILD-SNAPSHOT"],
 			"jedis29-redis20"   : [jedisVersion: "2.9.0", springDataRedisVersion: "2.0.0.BUILD-SNAPSHOT"],
-			"lettuce43-redis20" : [lettuceVersion: "4.3.1.Final", springDataRedisVersion: "2.0.0.BUILD-SNAPSHOT"],
+			"lettuce5-redis20" :  [lettuceVersion: "5.0.0.BUILD-SNAPSHOT", springDataRedisVersion: "2.0.0.BUILD-SNAPSHOT"],
 			"amqp20"            : [springAmqpVersion: "2.0.0.BUILD-SNAPSHOT"],
 			"spring50"          : [springVersion: "5.0.0.BUILD-SNAPSHOT"],
 			"tomcat85"          : [tomcatVersion: "8.5.13"],

--- a/spring-cloud-spring-service-connector/build.gradle
+++ b/spring-cloud-spring-service-connector/build.gradle
@@ -11,7 +11,7 @@ ext {
 
 	springDataRedisVersion = "2.0.0.BUILD-SNAPSHOT"
 	jedisVersion = "2.9.0"
-	lettuceVersion = "4.3.1.Final"
+	lettuceVersion = "5.0.0.BUILD-SNAPSHOT"
 
 	mysqlDriverVersion = "6.0.6"
 	mariadbDriverVersion = "1.5.9"
@@ -52,7 +52,7 @@ dependencies {
 		exclude(group: 'org.springframework', module: 'spring-context-support')
 	}
 	optional("redis.clients:jedis:$jedisVersion")
-	optional("biz.paluch.redis:lettuce:$lettuceVersion")
+	optional("io.lettuce:lettuce-core:$lettuceVersion")
 
 	optional("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") {
 		exclude(group: 'org.springframework', module: 'spring-beans')

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/MongoDbFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/MongoDbFactoryCreator.java
@@ -1,8 +1,5 @@
 package org.springframework.cloud.service.document;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.UnknownHostException;
 
 import org.springframework.cloud.service.AbstractServiceConnectorCreator;
@@ -11,12 +8,9 @@ import org.springframework.cloud.service.ServiceConnectorCreationException;
 import org.springframework.cloud.service.common.MongoServiceInfo;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientOptions.Builder;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
@@ -27,6 +21,7 @@ import com.mongodb.WriteConcern;
  * @author Ramnivas Laddad
  * @author Thomas Risberg
  * @author Chris Schaefer
+ * @author Mark Paluch
  */
 public class MongoDbFactoryCreator extends AbstractServiceConnectorCreator<MongoDbFactory, MongoServiceInfo> {
 	@Override
@@ -51,25 +46,7 @@ public class MongoDbFactoryCreator extends AbstractServiceConnectorCreator<Mongo
 	}
 
 	private MongoClientOptions.Builder getMongoOptions(MongoDbFactoryConfig config) {
-		MongoClientOptions.Builder builder;
-		
-		Method builderMethod = ClassUtils.getMethodIfAvailable(MongoClientOptions.class, "builder");
-		if (builderMethod != null) {
-			builder = (Builder) ReflectionUtils.invokeMethod(builderMethod, null);
-		} else {
-			Constructor<Builder> builderConstructor = ClassUtils.getConstructorIfAvailable(MongoClientOptions.Builder.class);
-			try {
-				builder = builderConstructor.newInstance(new Object[0]);
-			} catch (InstantiationException e) {
-				throw new IllegalStateException(e);
-			} catch (IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			} catch (IllegalArgumentException e) {
-				throw new IllegalStateException(e);
-			} catch (InvocationTargetException e) {
-				throw new IllegalStateException(e);
-			}
-		}
+		MongoClientOptions.Builder builder = MongoClientOptions.builder();
 
 		if (config != null) {
 			if (config.getConnectionsPerHost() != null) {

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisConnectionFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/keyval/RedisConnectionFactoryCreator.java
@@ -23,7 +23,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 public class RedisConnectionFactoryCreator extends AbstractServiceConnectorCreator<RedisConnectionFactory, RedisServiceInfo> {
 
 	private static final String JEDIS_CLASS_NAME = "redis.clients.jedis.Jedis";
-	private static final String LETTUCE_CLASS_NAME = "com.lambdaworks.redis.RedisClient";
+	private static final String LETTUCE_CLASS_NAME = "io.lettuce.core.RedisClient";
 
 	@Override
 	public RedisConnectionFactory create(RedisServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {


### PR DESCRIPTION
* Upgrade to io.lettuce:lettuce-core 5.0 SNAPSHOT.
* Simplify MongoDB configuration: Remove reflection access because Spring Data MongoDB requires MongoDB driver 3.x.

Fixes #195 