### PR TITLE
Upgrade to the latest Spring IO plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'io.spring.gradle:propdeps-plugin:0.0.8'
-		classpath 'io.spring.gradle:spring-io-plugin:0.0.6.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.7.RELEASE'
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
 	}
 }


### PR DESCRIPTION
Previous versions of the plugin are incompatible with the latest PropDeps plugin. This commit upgrades theSpring IO plugin to a version that is compatible.