### PR TITLE
Fix #205: Make tag matching case-insensitive

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreator.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.cloudfoundry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 import org.springframework.cloud.ServiceInfoCreator;
@@ -30,12 +31,16 @@ public abstract class CloudFoundryServiceInfoCreator<SI extends ServiceInfo> imp
 	@SuppressWarnings("unchecked")
 	protected boolean tagsMatch(Map<String, Object> serviceData) {
 		List<String> serviceTags = (List<String>) serviceData.get("tags");
+		ListIterator<String> iterator = serviceTags.listIterator();
+		while (iterator.hasNext()) {
+			iterator.set(iterator.next().toLowerCase());
+		}
 		return tags.containsOne(serviceTags);
 	}
 
 	protected boolean labelStartsWithTag(Map<String, Object> serviceData) {
 		String label = (String) serviceData.get("label");
-		return tags.startsWith(label);
+		return tags.startsWith(label.toLowerCase());
 	}
 
 	protected boolean uriMatchesScheme(Map<String, Object> serviceData) {

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/Tags.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/Tags.java
@@ -7,6 +7,9 @@ public class Tags {
 	private String[] values;
 
 	public Tags(String... values) {
+		for (int i=0; i<values.length; i++) {
+			values[i] = values[i].toLowerCase();
+		}
 		this.values = values;
 	}
 

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreatorTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreatorTest.java
@@ -13,11 +13,12 @@ public class CloudFoundryServiceInfoCreatorTest {
 
 	@Test
 	public void tagsMatch() {
-		DummyServiceInfoCreator serviceInfoCreator = new DummyServiceInfoCreator(new Tags("firstTag", "secondTag"));
+		DummyServiceInfoCreator serviceInfoCreator = new DummyServiceInfoCreator(new Tags("firstTag", "secondTag", "capitalTag"));
 
 		assertAcceptedWithTags(serviceInfoCreator, "firstTag", "noMatchTag");
 		assertAcceptedWithTags(serviceInfoCreator, "noMatchTag", "secondTag");
 		assertAcceptedWithTags(serviceInfoCreator, "firstTag", "secondTag");
+		assertAcceptedWithTags(serviceInfoCreator, "CapitalTag");
 
 		assertNotAcceptedWithTags(serviceInfoCreator, "noMatchTag");
 		assertNotAcceptedWithTags(serviceInfoCreator);


### PR DESCRIPTION
Attempts to match tags or labels against Cloud Foundry parameters will now be case-insensitive. This is accomplished by converting the tag names to lowercase in the `Tag` constructor, and converting the tags and labels from `serviceData` to lowercase before performing the comparison. 

Also added an `assert()` to tests to ensure this works as expected.