### PR TITLE
Shrink Cloud Foundry Connector Footprint

### DIFF
--- a/spring-cloud-cloudfoundry-connector/build.gradle
+++ b/spring-cloud-cloudfoundry-connector/build.gradle
@@ -13,21 +13,20 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply from: "publish-maven.gradle"
 
 ext {
-	jacksonVersion = "2.3.3"
+	jsonVersion = "20171018"
 }
 
 dependencies {
 	compile project(':spring-cloud-connectors-core')
-	compile("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-	compile("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+	compile("org.json:json:$jsonVersion")
 }
 
 shadowJar {
 	classifier = null
 	dependencies {
-		include dependency('com.fasterxml.jackson.core:jackson-.*')
+		include dependency('org.json:json')
 	}
-	relocate 'com.fasterxml.jackson', 'org.springframework.cloud.cloudfoundry.com.fasterxml.jackson'
+	relocate 'org.json', 'org.springframework.cloud.cloudfoundry.org.json'
 }
 
 assemble.dependsOn shadowJar

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnector.java
@@ -4,15 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.json.JSONObject;
 import org.springframework.cloud.AbstractCloudConnector;
 import org.springframework.cloud.CloudException;
 import org.springframework.cloud.FallbackServiceInfoCreator;
 import org.springframework.cloud.app.ApplicationInstanceInfo;
 import org.springframework.cloud.service.BaseServiceInfo;
 import org.springframework.cloud.util.EnvironmentAccessor;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * 
@@ -21,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Object>> {
 
-	private ObjectMapper objectMapper = new ObjectMapper();
 	private EnvironmentAccessor environment = new EnvironmentAccessor();
 	
 	private ApplicationInstanceInfoCreator applicationInstanceInfoCreator = new ApplicationInstanceInfoCreator();
@@ -43,8 +43,8 @@ public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Obj
 	public ApplicationInstanceInfo getApplicationInstanceInfo() {
 		try {
 			@SuppressWarnings("unchecked")
-			Map<String, Object> rawApplicationInstanceInfo 
-				= objectMapper.readValue(environment.getEnvValue("VCAP_APPLICATION"), Map.class);
+			Map<String, Object> rawApplicationInstanceInfo
+				= new JSONObject(environment.getEnvValue("VCAP_APPLICATION")).toMap();
 			return applicationInstanceInfoCreator.createApplicationInstanceInfo(rawApplicationInstanceInfo);
 		} catch (Exception e) {
 			throw new CloudException(e);
@@ -71,7 +71,8 @@ public class CloudFoundryConnector extends AbstractCloudConnector<Map<String,Obj
 		
 		if (servicesString != null && servicesString.length() > 0) {
 			try {
-				rawServices = objectMapper.readValue(servicesString, CloudFoundryRawServiceData.class);
+				rawServices = new CloudFoundryRawServiceData(new JSONObject(servicesString).toMap().entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, entry -> (List<Map<String, Object>>) entry.getValue())));
 			} catch (Exception e) {
 				throw new CloudException(e);
 			}

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorTest.java
@@ -8,14 +8,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.UriBasedServiceInfo;
 import org.springframework.cloud.util.EnvironmentAccessor;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -36,8 +35,6 @@ public abstract class AbstractCloudFoundryConnectorTest {
 	protected static final int port = 1234;
 	protected static String username = "myuser";
 	protected static final String password = "mypass";
-
-	private static ObjectMapper objectMapper = new ObjectMapper();
 	
 	@Before
 	public void setup() {
@@ -116,7 +113,7 @@ public abstract class AbstractCloudFoundryConnectorTest {
 	@SuppressWarnings("unchecked")
 	private static String getServiceLabel(String servicePayload) {
 		try {
-			Map<String, Object> serviceMap = objectMapper.readValue(servicePayload, Map.class);
+			Map<String, Object> serviceMap = new JSONObject(servicePayload).toMap();
 			return serviceMap.get("label").toString();
 		} catch (Exception e) {
 			return null;

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreatorTests.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreatorTests.java
@@ -22,10 +22,9 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONObject;
 import org.junit.Test;
 import org.springframework.cloud.service.common.CassandraServiceInfo;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Unit tests for link {@link CassandraServiceInfoCreator}.
@@ -33,8 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Mark Paluch
  */
 public class CassandraServiceInfoCreatorTests extends AbstractCloudFoundryConnectorTest {
-
-	private ObjectMapper mapper = new ObjectMapper();
 
 	@Test
 	public void shouldCreateServiceInfo() throws Exception {
@@ -91,7 +88,7 @@ public class CassandraServiceInfoCreatorTests extends AbstractCloudFoundryConnec
 	}
 
 	private Map readServiceData(String resource) throws java.io.IOException {
-		return mapper.readValue(readTestDataFile(resource), Map.class);
+		return new JSONObject(readTestDataFile(resource)).toMap();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Previously, the Cloud Foundry Connector utilized Jackson for parsing the `VCAP_SERVICES` JSON payload.  While Jackson should be the default choice for most JSON parsing, the fact that the project does not need Object binding means that it is overkill for the need.  In addition, since whichever JSON
parser is chosen must be included in the distributable JAR and not shared with the rest of the application (which is likely to have its own version of Jackson) the size of the Jackson libraries becomes a significant concern.

This change updates the code to use the `org.json:json` parser and shrinks the `spring-cloud-cloudfoundry-connector` from 1.2M to 84K with no difference in functionality.