### PR TITLE
Revert "Shrink Cloud Foundry Connector Footprint"

### DIFF
--- a/spring-cloud-cloudfoundry-connector/build.gradle
+++ b/spring-cloud-cloudfoundry-connector/build.gradle
@@ -13,20 +13,21 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply from: "publish-maven.gradle"
 
 ext {
-	jsonVersion = "20171018"
+	jacksonVersion = "2.3.3"
 }
 
 dependencies {
 	compile project(':spring-cloud-connectors-core')
-	compile("org.json:json:$jsonVersion")
+	compile("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+	compile("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 }
 
 shadowJar {
 	classifier = null
 	dependencies {
-		include dependency('org.json:json')
+		include dependency('com.fasterxml.jackson.core:jackson-.*')
 	}
-	relocate 'org.json', 'org.springframework.cloud.cloudfoundry.org.json'
+	relocate 'com.fasterxml.jackson', 'org.springframework.cloud.cloudfoundry.com.fasterxml.jackson'
 }
 
 assemble.dependsOn shadowJar

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/AbstractCloudFoundryConnectorTest.java
@@ -8,13 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.service.UriBasedServiceInfo;
 import org.springframework.cloud.util.EnvironmentAccessor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -35,6 +36,8 @@ public abstract class AbstractCloudFoundryConnectorTest {
 	protected static final int port = 1234;
 	protected static String username = "myuser";
 	protected static final String password = "mypass";
+
+	private static ObjectMapper objectMapper = new ObjectMapper();
 	
 	@Before
 	public void setup() {
@@ -113,7 +116,7 @@ public abstract class AbstractCloudFoundryConnectorTest {
 	@SuppressWarnings("unchecked")
 	private static String getServiceLabel(String servicePayload) {
 		try {
-			Map<String, Object> serviceMap = new JSONObject(servicePayload).toMap();
+			Map<String, Object> serviceMap = objectMapper.readValue(servicePayload, Map.class);
 			return serviceMap.get("label").toString();
 		} catch (Exception e) {
 			return null;

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreatorTests.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CassandraServiceInfoCreatorTests.java
@@ -22,9 +22,10 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONObject;
 import org.junit.Test;
 import org.springframework.cloud.service.common.CassandraServiceInfo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Unit tests for link {@link CassandraServiceInfoCreator}.
@@ -32,6 +33,8 @@ import org.springframework.cloud.service.common.CassandraServiceInfo;
  * @author Mark Paluch
  */
 public class CassandraServiceInfoCreatorTests extends AbstractCloudFoundryConnectorTest {
+
+	private ObjectMapper mapper = new ObjectMapper();
 
 	@Test
 	public void shouldCreateServiceInfo() throws Exception {
@@ -88,7 +91,7 @@ public class CassandraServiceInfoCreatorTests extends AbstractCloudFoundryConnec
 	}
 
 	private Map readServiceData(String resource) throws java.io.IOException {
-		return new JSONObject(readTestDataFile(resource)).toMap();
+		return mapper.readValue(readTestDataFile(resource), Map.class);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Reverts spring-cloud/spring-cloud-connectors#218

It turns out there are licensing concerns with `org.json:json` that have causes us to remove it from other parts of Spring. See https://github.com/spring-projects/spring-boot/issues/5929. The goal of this change is good, but we should find another alternative to Jackson. 