### PR TITLE
Update jackson dependencies to 2.9.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
 
 	cglibVersion = "3.1"
 
-	jacksonVersion = "2.3.3"
+	jacksonVersion = "2.9.5"
 
 	junitVersion = "4.11"
 	mockitoVersion = "1.9.5"


### PR DESCRIPTION
jackson.core:jackson-databind:2.3.3 2.3.3 is affected by the following CVEs:

- CVE-2017-15095 
- CVE-2017-17485 
- CVE-2017-7525
- CVE-2018-5968 
- CVE-2018-7489