### PR TITLE
Add support for reactive MongoDB connectors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ configure(rootProject) {
 
 ext {
 	matrix = [
-			"driver36-mongo20"  : [mongoDriverVersion: "3.6.3", springDataMongoVersion: "2.0.0.RELEASE"],
+			"driver36-mongo20"  : [mongoDriverVersion: "3.6.3", mongoDriverReactiveStreamsVersion: "1.7.1", springDataMongoVersion: "2.0.0.RELEASE"],
 			"jedis29-redis20"   : [jedisVersion: "2.9.0", springDataRedisVersion: "2.0.0.RELEASE"],
 			"lettuce5-redis20"  : [lettuceVersion: "5.0.0.RELEASE", springDataRedisVersion: "2.0.0.RELEASE"],
 			"driver330-cass20"  : [cassandraDriverVersion: "3.3.0", springDataCassandraVersion: "2.0.0.RELEASE"],

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ configure(rootProject) {
 
 ext {
 	matrix = [
-			"driver34-mongo20"  : [mongoDriverVersion: "3.4.2", springDataMongoVersion: "2.0.0.RELEASE"],
+			"driver36-mongo20"  : [mongoDriverVersion: "3.6.3", springDataMongoVersion: "2.0.0.RELEASE"],
 			"jedis29-redis20"   : [jedisVersion: "2.9.0", springDataRedisVersion: "2.0.0.RELEASE"],
 			"lettuce5-redis20"  : [lettuceVersion: "5.0.0.RELEASE", springDataRedisVersion: "2.0.0.RELEASE"],
 			"driver330-cass20"  : [cassandraDriverVersion: "3.3.0", springDataCassandraVersion: "2.0.0.RELEASE"],

--- a/spring-cloud-spring-service-connector/build.gradle
+++ b/spring-cloud-spring-service-connector/build.gradle
@@ -8,6 +8,7 @@ ext {
 
 	springDataMongoVersion = "2.0.0.RELEASE"
 	mongoDriverVersion = "3.6.3"
+	mongoDriverReactiveStreamsVersion = "1.7.1"
 
 	springDataRedisVersion = "2.0.0.RELEASE"
 	jedisVersion = "2.9.0"
@@ -65,6 +66,7 @@ dependencies {
 		exclude(group: 'org.mongodb', module: 'mongo-java-driver')
 	}
 	optional("org.mongodb:mongo-java-driver:${mongoDriverVersion}")
+	optional("org.mongodb:mongodb-driver-reactivestreams:${mongoDriverReactiveStreamsVersion}")
 
 	optional("org.springframework.data:spring-data-cassandra:$springDataCassandraVersion") {
 		exclude(group: 'org.springframework', module: 'spring-beans')

--- a/spring-cloud-spring-service-connector/build.gradle
+++ b/spring-cloud-spring-service-connector/build.gradle
@@ -7,7 +7,7 @@ ext {
 	springAmqpVersion = "2.0.0.RELEASE"
 
 	springDataMongoVersion = "2.0.0.RELEASE"
-	mongoDriverVersion = "3.4.2"
+	mongoDriverVersion = "3.6.3"
 
 	springDataRedisVersion = "2.0.0.RELEASE"
 	jedisVersion = "2.9.0"

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/ReactiveMongoDatabaseFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/ReactiveMongoDatabaseFactoryCreator.java
@@ -1,0 +1,110 @@
+package org.springframework.cloud.service.document;
+
+import java.util.concurrent.TimeUnit;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoException;
+import com.mongodb.WriteConcern;
+import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.ConnectionPoolSettings;
+import com.mongodb.connection.ServerSettings;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.connection.SslSettings;
+
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.springframework.cloud.service.AbstractServiceConnectorCreator;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.ServiceConnectorCreationException;
+import org.springframework.cloud.service.common.MongoServiceInfo;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
+
+/**
+ * Simplified access to creating reactive MongoDB service objects.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveMongoDatabaseFactoryCreator extends AbstractServiceConnectorCreator<ReactiveMongoDatabaseFactory, MongoServiceInfo> {
+	@Override
+	public ReactiveMongoDatabaseFactory create(MongoServiceInfo serviceInfo, ServiceConnectorConfig config) {
+		try {
+			ConnectionString connectionString = new ConnectionString(serviceInfo.getUri());
+			MongoClientSettings settings = getMongoClientSettings(connectionString, (MongoDbFactoryConfig) config);
+
+			SimpleReactiveMongoDatabaseFactory mongoDbFactory = createMongoDbFactory(settings, connectionString);
+
+			return configure(mongoDbFactory, (MongoDbFactoryConfig) config);
+		} catch (MongoException e) {
+			throw new ServiceConnectorCreationException(e);
+		}
+	}
+
+	private static SimpleReactiveMongoDatabaseFactory createMongoDbFactory(MongoClientSettings settings, ConnectionString connectionString) {
+		return new SimpleReactiveMongoDatabaseFactory(MongoClients.create(settings), connectionString.getDatabase());
+	}
+
+	private static MongoClientSettings getMongoClientSettings(ConnectionString connectionString,
+			MongoDbFactoryConfig config) {
+
+		ConnectionPoolSettings poolSettings = getConnectionPoolSettings(connectionString, config);
+
+		MongoClientSettings.Builder builder = MongoClientSettings.builder()
+				.clusterSettings(ClusterSettings.builder()
+						.applyConnectionString(connectionString).build())
+				.connectionPoolSettings(poolSettings)
+				.serverSettings(ServerSettings.builder()
+						.applyConnectionString(connectionString).build())
+				.sslSettings(SslSettings.builder().applyConnectionString(connectionString)
+						.build())
+				.socketSettings(SocketSettings.builder()
+						.applyConnectionString(connectionString).build());
+		
+		if (connectionString.getCredential() != null) {
+            builder.credential(connectionString.getCredential());
+        }
+        if (connectionString.getReadPreference() != null) {
+            builder.readPreference(connectionString.getReadPreference());
+        }
+        if (connectionString.getReadConcern() != null) {
+            builder.readConcern(connectionString.getReadConcern());
+        }
+        if (connectionString.getWriteConcern() != null) {
+            builder.writeConcern(connectionString.getWriteConcern());
+        }
+        if (connectionString.getApplicationName() != null) {
+            builder.applicationName(connectionString.getApplicationName());
+        }
+        
+		if (config != null && config.getWriteConcern() != null) {
+			builder.writeConcern(new WriteConcern(config.getWriteConcern()));
+		}
+
+		return builder.build();
+	}
+
+	private static ConnectionPoolSettings getConnectionPoolSettings(ConnectionString connectionString, MongoDbFactoryConfig config) {
+		
+		ConnectionPoolSettings.Builder poolSettingBuilder = ConnectionPoolSettings
+				.builder().applyConnectionString(connectionString);
+
+		if (config != null) {
+			if (config.getMaxWaitTime() != null) {
+				poolSettingBuilder.maxWaitTime(config.getMaxWaitTime(),
+						TimeUnit.MILLISECONDS);
+			}
+		}
+
+		return poolSettingBuilder.build();
+	}
+
+	public SimpleReactiveMongoDatabaseFactory configure(SimpleReactiveMongoDatabaseFactory mongoDbFactory, MongoDbFactoryConfig config) {
+		if (config != null && config.getWriteConcern() != null) {
+			WriteConcern writeConcern = WriteConcern.valueOf(config.getWriteConcern());
+			if (writeConcern != null) {
+				mongoDbFactory.setWriteConcern(writeConcern);
+			}
+		}
+		return mongoDbFactory;
+	}
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/ReactiveMongoDatabaseFactoryFactory.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/document/ReactiveMongoDatabaseFactoryFactory.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.service.document;
+
+import org.springframework.cloud.service.AbstractCloudServiceConnectorFactory;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+
+/**
+ * Spring factory bean for reactive MongoDb service.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveMongoDatabaseFactoryFactory extends AbstractCloudServiceConnectorFactory<ReactiveMongoDatabaseFactory> {
+	public ReactiveMongoDatabaseFactoryFactory(String serviceId, ServiceConnectorConfig serviceConnectorConfiguration) {
+		super(serviceId, ReactiveMongoDatabaseFactory.class, serviceConnectorConfiguration);
+	}
+}

--- a/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -5,6 +5,7 @@ org.springframework.cloud.service.relational.DB2DataSourceCreator
 org.springframework.cloud.service.keyval.RedisConnectionFactoryCreator
 org.springframework.cloud.service.keyval.SpringData1RedisConnectionFactoryCreator
 org.springframework.cloud.service.document.MongoDbFactoryCreator
+org.springframework.cloud.service.document.ReactiveMongoDatabaseFactoryCreator
 org.springframework.cloud.service.messaging.RabbitConnectionFactoryCreator
 org.springframework.cloud.service.smtp.MailSenderCreator
 org.springframework.cloud.service.relational.SqlServerDataSourceCreator

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/mongo/ReactiveMongoDatabaseFactoryFactoryTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/mongo/ReactiveMongoDatabaseFactoryFactoryTest.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.service.mongo;
+
+import org.mockito.Mock;
+
+import org.springframework.cloud.service.AbstractCloudServiceConnectorFactoryTest;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.common.MongoServiceInfo;
+import org.springframework.cloud.service.document.ReactiveMongoDatabaseFactoryFactory;
+import org.springframework.cloud.util.UriInfo;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+
+/**
+ * @author Mark Paluch
+ */
+public class ReactiveMongoDatabaseFactoryFactoryTest extends AbstractCloudServiceConnectorFactoryTest<ReactiveMongoDatabaseFactoryFactory, ReactiveMongoDatabaseFactory, MongoServiceInfo> {
+	@Mock ReactiveMongoDatabaseFactory mockConnector;
+	
+	public ReactiveMongoDatabaseFactoryFactory createTestCloudServiceConnectorFactory(String id, ServiceConnectorConfig config) {
+		return new ReactiveMongoDatabaseFactoryFactory(id, config);
+	}
+	
+	public Class<ReactiveMongoDatabaseFactory> getConnectorType() {
+		return ReactiveMongoDatabaseFactory.class;
+	}
+	
+	public ReactiveMongoDatabaseFactory getMockConnector() {
+		return mockConnector;
+	}
+	
+	public MongoServiceInfo getTestServiceInfo(String id) {
+		return new MongoServiceInfo(id, new UriInfo("mongodb", "host", 0, "username", "password", "db").getUriString());
+	}
+}

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/mongo/ReactiveMongoServiceConnectorCreatorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/mongo/ReactiveMongoServiceConnectorCreatorTest.java
@@ -1,0 +1,108 @@
+package org.springframework.cloud.service.mongo;
+
+import java.util.List;
+
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.reactivestreams.client.MongoClient;
+import org.junit.Test;
+
+import org.springframework.cloud.service.common.MongoServiceInfo;
+import org.springframework.cloud.service.document.ReactiveMongoDatabaseFactoryCreator;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.StringUtils;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for reactive Mongo service connector creators.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveMongoServiceConnectorCreatorTest {
+	private static final String TEST_HOST = "10.20.30.40";
+	private static final String TEST_HOST_1 = "10.20.30.41";
+	private static final String TEST_HOST_2 = "10.20.30.42";
+	private static final int TEST_PORT = 1234;
+	private static final int TEST_PORT_DEFAULT = 27017;
+	private static final String TEST_USERNAME = "myuser";
+	private static final String TEST_PASSWORD = "mypass";
+	private static final String TEST_DB = "mydb";
+	private static final String MONGODB_SCHEME = "mongodb";
+	private static final String[] TEST_HOSTS = new String[] { TEST_HOST, TEST_HOST_1, TEST_HOST_2 };
+
+	private ReactiveMongoDatabaseFactoryCreator testCreator = new ReactiveMongoDatabaseFactoryCreator();
+
+	@Test
+	public void cloudMongoCreationNoConfig() throws Exception {
+		MongoServiceInfo serviceInfo = new MongoServiceInfo("id", TEST_HOST, TEST_PORT, TEST_USERNAME, TEST_PASSWORD, TEST_DB);
+
+		ReactiveMongoDatabaseFactory mongoDbFactory = testCreator.create(serviceInfo, null);
+		assertNotNull(mongoDbFactory);
+
+		MongoClient mongoClient = getMongoClientField(mongoDbFactory);
+
+		MongoCredential credentials = mongoClient.getSettings().getCredential();
+
+		List<ServerAddress> addresses = extractServerAddresses(mongoClient);
+		assertEquals(1, addresses.size());
+
+		ServerAddress address = addresses.get(0);
+
+		assertEquals(serviceInfo.getHost(), address.getHost());
+		assertEquals(serviceInfo.getPort(), address.getPort());
+		assertEquals(serviceInfo.getUserName(), credentials.getUserName());
+		assertNotNull(credentials.getPassword());
+
+		// Don't do connector.getDatabase().getName() as that will try to initiate the connection
+		assertEquals(serviceInfo.getDatabase(), ReflectionTestUtils.getField(mongoDbFactory, "databaseName"));
+	}
+
+	@Test
+	public void cloudMongoCreationWithMultipleHostsByUri() throws Exception {
+		String uri = String.format("%s://%s:%s@%s:%s/%s", MONGODB_SCHEME, TEST_USERNAME, TEST_PASSWORD,
+				StringUtils.arrayToDelimitedString(TEST_HOSTS, ","), TEST_PORT, TEST_DB);
+
+		MongoServiceInfo serviceInfo = new MongoServiceInfo("id", uri);
+
+		ReactiveMongoDatabaseFactory mongoDbFactory = testCreator.create(serviceInfo, null);
+		assertNotNull(mongoDbFactory);
+
+		MongoClient mongoClient = getMongoClientField(mongoDbFactory);
+
+		List<ServerAddress> addresses = extractServerAddresses(mongoClient);
+		assertEquals(3, addresses.size());
+
+		MongoCredential credentials = mongoClient.getSettings().getCredential();
+		assertEquals(TEST_USERNAME, credentials.getUserName());
+		assertNotNull(credentials.getPassword());
+
+		// Don't do connector.getDatabase().getName() as that will try to initiate the connection
+		assertEquals(TEST_DB, ReflectionTestUtils.getField(mongoDbFactory, "databaseName"));
+
+		ServerAddress address1 = addresses.get(0);
+		assertEquals(TEST_HOST, address1.getHost());
+		assertEquals(TEST_PORT_DEFAULT, address1.getPort());
+
+		ServerAddress address2 = addresses.get(1);
+		assertEquals(TEST_HOST_1, address2.getHost());
+		assertEquals(TEST_PORT_DEFAULT, address2.getPort());
+
+		ServerAddress address3 = addresses.get(2);
+		assertEquals(TEST_HOST_2, address3.getHost());
+		assertEquals(TEST_PORT, address3.getPort());
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ServerAddress> extractServerAddresses(MongoClient client) {
+		return client.getSettings().getClusterSettings().getHosts();
+	}
+
+	private MongoClient getMongoClientField(ReactiveMongoDatabaseFactory mongoDbFactory) {
+		MongoClient mongo = (MongoClient) ReflectionTestUtils.getField(mongoDbFactory, "mongo");
+		assertNotNull(mongo);
+		return mongo;
+	}
+
+}


### PR DESCRIPTION
We now provide a connector for MongoDB's ReactiveStreams driver. `mongodb-driver-reactivestreams` is an optional dependency. Upgraded MongoDB Java driver to align with Reactive Streams driver version requirements.