### PR TITLE
Update RabbitConnectionFactoryCreator to set setAutomaticRecoveryEnabled to false

### DIFF
--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/messaging/RabbitConnectionFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/messaging/RabbitConnectionFactoryCreator.java
@@ -38,6 +38,8 @@ public class RabbitConnectionFactoryCreator extends	AbstractServiceConnectorCrea
 
 	private com.rabbitmq.client.ConnectionFactory createRabbitConnectionFactory(AmqpServiceInfo serviceInfo) {
 		com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+		connectionFactory.setAutomaticRecoveryEnabled(false);
+		
 		if (serviceInfo.getUris() != null && serviceInfo.getUris().size() > 0) {
 			setConnectionFactoryUri(connectionFactory, serviceInfo.getUris().get(0));
 		} else {


### PR DESCRIPTION
In order to avoid the following warning on startup when spring-cloud-connectors are activated on cloud foundry:

```
Automatic Recovery is Enabled in the provided connection factory
while Spring AMQP is compatible with this feature, it
prefers to use its own recovery mechanisms; when this option is true, you may receive
'AutoRecoverConnectionNotCurrentlyOpenException's until the connection is recovered.
```

The RabbitConnectionFactoryCreator class should be updated to setAutomaticRecoveryEnabled equaled to false when constructing a Rabbit ConnectFactory, which is consistent with the default behavior of the spring-amqp CachingConnectionFactory when it builds a default ConnectionFactory:
https://github.com/spring-projects/spring-amqp/blob/master/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java#L277

This helps avoid issues that we have seen on spring boot 2 + spring cloud finchley + on demand rabbitmq clusters that are repaved or configuration settings are modified.  In those cases cluster members are recreated or processes on the VMs are cycled by bosh.  When this would happen we would see AutoRecoverConnectionNotCurrentlyOpenException instead of having spring-amqp retry.  An example project can be found here: https://github.com/xyloman/demo-spring-cloud-streams/tree/spring-boot-2  this has been updated to consume this fix if built locally. 