### PR TITLE
Update RabbitConnectionFactoryCreator to set setAutomaticRecoveryEnabled to false for spring boot 1.5.x

### DIFF
--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/messaging/RabbitConnectionFactoryCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/messaging/RabbitConnectionFactoryCreator.java
@@ -32,6 +32,7 @@ public class RabbitConnectionFactoryCreator extends	AbstractServiceConnectorCrea
 
 	private com.rabbitmq.client.ConnectionFactory createRabbitConnectionFactory(AmqpServiceInfo serviceInfo) {
 		com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+		connectionFactory.setAutomaticRecoveryEnabled(false);
 		if (serviceInfo.getUris() != null && serviceInfo.getUris().size() > 0) {
 			setConnectionFactoryUri(connectionFactory, serviceInfo.getUris().get(0));
 		} else {


### PR DESCRIPTION
Similar to #234, did some testing on spring boot 1.5.17.RELEASE this evening and got a similar exception where autoRecovery was disabled when using the service connector.  Is it possible to get this merged into 1.2.7 for spring boot 1.5.x applications?

```
Caused by: org.springframework.amqp.rabbit.connection.AutoRecoverConnectionNotCurrentlyOpenException: Auto recovery connection is not currently open
	at org.springframework.amqp.rabbit.connection.SimpleConnection.isOpen(SimpleConnection.java:99)
	at org.springframework.amqp.rabbit.connection.CachingConnectionFactory$ChannelCachingConnectionProxy.isOpen(CachingConnectionFactory.java:1280)
	at org.springframework.amqp.rabbit.connection.CachingConnectionFactory.getChannel(CachingConnectionFactory.java:449)
	at org.springframework.amqp.rabbit.connection.CachingConnectionFactory.access$1300(CachingConnectionFactory.java:102)
	at org.springframework.amqp.rabbit.connection.CachingConnectionFactory$ChannelCachingConnectionProxy.createChannel(CachingConnectionFactory.java:1213)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.doExecute(RabbitTemplate.java:1443)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.execute(RabbitTemplate.java:1419)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.send(RabbitTemplate.java:713)
	at org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint.send(AmqpOutboundEndpoint.java:134)
	at org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint.handleRequestMessage(AmqpOutboundEndpoint.java:122)
	at org.springframework.integration.handler.AbstractReplyProducingMessageHandler.handleMessageInternal(AbstractReplyProducingMessageHandler.java:109)
	at org.springframework.integration.handler.AbstractMessageHandler.handleMessage(AbstractMessageHandler.java:127)
	... 132 more
```