### PR TITLE
Add support for CloudFoundry NFS and SMB volumes

### DIFF
--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryVolumeServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/CloudFoundryVolumeServiceInfoCreator.java
@@ -1,0 +1,53 @@
+package org.springframework.cloud.cloudfoundry;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.service.common.VolumeServiceInfo;
+
+/**
+ * Provides an implementation of {@link CloudFoundryVolumeServiceInfoCreator} that detects CloudFoundry Volume service
+ * tagged services bound to a Cloud Foundry deployed application.  This class will be discovered and
+ * used automatically in a Spring Cloud Connector enabled application.
+ *
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public abstract class CloudFoundryVolumeServiceInfoCreator<SI extends VolumeServiceInfo> extends CloudFoundryServiceInfoCreator<SI> {
+
+	public CloudFoundryVolumeServiceInfoCreator(Tags tags, String... uriSchemes) {
+		super(tags, uriSchemes);
+	}
+
+	/**
+	 * Parses CloudFoundry serviceData Map and returns a normalized VolumeServiceInfo instance
+	 * to be used by Spring Cloud service connector creators.  This Cloud Foundry serviceData
+	 * Map is created based on the VCAP_SERVICES environment variable.
+	 *
+	 * @param serviceData a java.util.Map containing the following required fields:  name,
+	 *                    containerDir and mode
+	 *
+	 * @return {@link VolumeServiceInfo VolumeServiceInfo}
+	 */
+	@Override
+	public SI createServiceInfo(Map<String, Object> serviceData) {
+
+		String id = (String) serviceData.get("name");
+
+		List<Map<String,String>> volumeMounts = (List<Map<String,String>>) serviceData.get("volume_mounts");
+
+		Collection<File> mounts = new ArrayList<>();
+		for (Map<String,String> volumeMount : volumeMounts) {
+			File containerDir = new File(volumeMount.get("container_dir"));
+			mounts.add(containerDir);
+		}
+
+		return (SI) newVolumeServiceInfo(id, Collections.unmodifiableCollection(mounts));
+	}
+
+	protected abstract VolumeServiceInfo newVolumeServiceInfo(String id, Collection<File> mounts);
+}

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/NfsVolumeServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/NfsVolumeServiceInfoCreator.java
@@ -1,0 +1,26 @@
+package org.springframework.cloud.cloudfoundry;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.springframework.cloud.service.common.NfsVolumeServiceInfo;
+import org.springframework.cloud.service.common.VolumeServiceInfo;
+
+/**
+ * Concrete implementation of CloudFoundryVolumeServiceInfoCreator for NFS
+ *
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class NfsVolumeServiceInfoCreator extends CloudFoundryVolumeServiceInfoCreator<NfsVolumeServiceInfo> {
+
+	public NfsVolumeServiceInfoCreator() {
+		super(new Tags("nfs"));
+	}
+
+	@Override
+	protected VolumeServiceInfo newVolumeServiceInfo(String id, Collection<File> mounts) {
+		return new NfsVolumeServiceInfo(id, mounts);
+	}
+
+}

--- a/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/SmbVolumeServiceInfoCreator.java
+++ b/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/SmbVolumeServiceInfoCreator.java
@@ -1,0 +1,26 @@
+package org.springframework.cloud.cloudfoundry;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.springframework.cloud.service.common.SmbVolumeServiceInfo;
+import org.springframework.cloud.service.common.VolumeServiceInfo;
+
+/**
+ * Concrete implementation of CloudFoundryVolumeServiceInfoCreator for SMB
+ *
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class SmbVolumeServiceInfoCreator extends CloudFoundryVolumeServiceInfoCreator<SmbVolumeServiceInfo> {
+
+	public SmbVolumeServiceInfoCreator() {
+		super(new Tags("smb"));
+	}
+
+	@Override
+	protected VolumeServiceInfo newVolumeServiceInfo(String id, Collection<File> mounts) {
+		return new SmbVolumeServiceInfo(id, mounts);
+	}
+
+}

--- a/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
+++ b/spring-cloud-cloudfoundry-connector/src/main/resources/META-INF/services/org.springframework.cloud.cloudfoundry.CloudFoundryServiceInfoCreator
@@ -9,3 +9,5 @@ org.springframework.cloud.cloudfoundry.OracleServiceInfoCreator
 org.springframework.cloud.cloudfoundry.DB2ServiceInfoCreator
 org.springframework.cloud.cloudfoundry.SqlServerServiceInfoCreator
 org.springframework.cloud.cloudfoundry.CassandraServiceInfoCreator
+org.springframework.cloud.cloudfoundry.NfsVolumeServiceInfoCreator
+org.springframework.cloud.cloudfoundry.SmbVolumeServiceInfoCreator

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorVolumeServiceTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorVolumeServiceTest.java
@@ -1,0 +1,93 @@
+package org.springframework.cloud.cloudfoundry;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.cloud.service.BaseServiceInfo;
+import org.springframework.cloud.service.ServiceInfo;
+import org.springframework.cloud.service.common.NfsVolumeServiceInfo;
+import org.springframework.cloud.service.common.SmbVolumeServiceInfo;
+import org.springframework.cloud.service.common.VolumeServiceInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * 
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class CloudFoundryConnectorVolumeServiceTest extends AbstractCloudFoundryConnectorTest {
+
+	@Test
+	public void volumeServiceInfoCreation() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+			.thenReturn(
+					getServicesPayload(
+							getVolumeServiceBinding("test-nfs-volume-info.json","service-1", "/a/path", "r"),
+							getVolumeServiceBinding("test-smb-volume-info.json","service-2", "/b/path", "rw")
+			));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		ServiceInfo info1 = getServiceInfo(serviceInfos, "service-1");
+		ServiceInfo info2 = getServiceInfo(serviceInfos, "service-2");
+
+		assertServiceFoundOfType(info1, NfsVolumeServiceInfo.class);
+		assertServiceFoundOfType(info2, SmbVolumeServiceInfo.class);
+
+		assertEquals(1, (((VolumeServiceInfo)info1).getVolumeInfos().size()));
+		assertEquals("/a/path", (((VolumeServiceInfo)info1).getVolumeInfos().stream().findFirst().get().getAbsolutePath()));
+
+		assertEquals(1, (((VolumeServiceInfo)info2).getVolumeInfos().size()));
+		assertEquals("/b/path", (((VolumeServiceInfo)info2).getVolumeInfos().stream().findFirst().get().getAbsolutePath()));
+	}
+
+	@Test
+	public void volumeServiceInfoCreationWithLabelNoTags() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(
+						getServicesPayload(
+								getVolumeServiceBinding("test-nfs-volume-info-with-label-no-tags.json","service-1", "/a/path", "r"),
+								getVolumeServiceBinding("test-smb-volume-info-with-label-no-tags.json","service-2", "/b/path", "rw")
+						));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		ServiceInfo info1 = getServiceInfo(serviceInfos, "service-1");
+		ServiceInfo info2 = getServiceInfo(serviceInfos, "service-2");
+
+		assertServiceFoundOfType(info1, NfsVolumeServiceInfo.class);
+		assertServiceFoundOfType(info2, SmbVolumeServiceInfo.class);
+
+		assertEquals(1, (((VolumeServiceInfo)info1).getVolumeInfos().size()));
+		assertEquals("/a/path", (((VolumeServiceInfo)info1).getVolumeInfos().stream().findFirst().get().getAbsolutePath()));
+
+		assertEquals(1, (((VolumeServiceInfo)info2).getVolumeInfos().size()));
+		assertEquals("/b/path", (((VolumeServiceInfo)info2).getVolumeInfos().stream().findFirst().get().getAbsolutePath()));
+	}
+
+	@Test
+	public void volumeServiceInfoCreationWithNoLabelNoTags() {
+		when(mockEnvironment.getEnvValue("VCAP_SERVICES"))
+				.thenReturn(
+						getServicesPayload(
+								getVolumeServiceBinding("test-volume-info-with-no-label-no-tags.json","service-1", "/a/path", "r"),
+								getVolumeServiceBinding("test-volume-info-with-no-label-no-tags.json","service-2", "/b/path", "rw")
+						));
+		List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+
+		ServiceInfo info1 = getServiceInfo(serviceInfos, "service-1");
+		ServiceInfo info2 = getServiceInfo(serviceInfos, "service-2");
+
+		assertServiceFoundOfType(info1, BaseServiceInfo.class);
+		assertServiceFoundOfType(info2, BaseServiceInfo.class);
+	}
+
+	private String getVolumeServiceBinding(String fileName, String serviceName, String containerDir, String mode) {
+		String payload = readTestDataFile(fileName);
+		payload = payload.replaceAll("\\$name", serviceName);
+		payload = payload.replace("$containerDir", containerDir);
+		payload = payload.replace("$mode", mode);
+		return payload;
+	}
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-nfs-volume-info-with-label-no-tags.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-nfs-volume-info-with-label-no-tags.json
@@ -1,0 +1,14 @@
+{
+	"label": "nfs",
+	"instance_name": "$name",
+	"name": "$name",
+	"plan": "Existing",
+	"tags": [],
+	"volume_mounts": [
+		{
+			"container_dir": "$containerDir",
+			"device_type": "shared",
+			"mode": "$mode"
+		}
+	]
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-nfs-volume-info.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-nfs-volume-info.json
@@ -1,0 +1,16 @@
+{
+	"label": "nfs",
+	"instance_name": "$name",
+	"name": "$name",
+	"plan": "Existing",
+	"tags": [
+		"nfs"
+	],
+	"volume_mounts": [
+		{
+			"container_dir": "$containerDir",
+			"device_type": "shared",
+			"mode": "$mode"
+		}
+	]
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smb-volume-info-with-label-no-tags.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smb-volume-info-with-label-no-tags.json
@@ -1,0 +1,14 @@
+{
+	"label": "smb",
+	"instance_name": "$name",
+	"name": "$name",
+	"plan": "Existing",
+	"tags": [],
+	"volume_mounts": [
+		{
+			"container_dir": "$containerDir",
+			"device_type": "shared",
+			"mode": "$mode"
+		}
+	]
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smb-volume-info.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-smb-volume-info.json
@@ -1,0 +1,16 @@
+{
+	"label": "smb",
+	"instance_name": "$name",
+	"name": "$name",
+	"plan": "Existing",
+	"tags": [
+		"smb"
+	],
+	"volume_mounts": [
+		{
+			"container_dir": "$containerDir",
+			"device_type": "shared",
+			"mode": "$mode"
+		}
+	]
+}

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-volume-info-with-no-label-no-tags.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-volume-info-with-no-label-no-tags.json
@@ -1,0 +1,12 @@
+{
+	"instance_name": "$name",
+	"name": "$name",
+	"plan": "Existing",
+	"volume_mounts": [
+		{
+			"container_dir": "$containerDir",
+			"device_type": "shared",
+			"mode": "$mode"
+		}
+	]
+}

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/AbstractCloudConnector.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/AbstractCloudConnector.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 
 import org.springframework.cloud.service.ServiceInfo;
 
+import static java.lang.String.format;
+
 
 /**
  * Helper abstract class to simplify {@link CloudConnector} implementations.

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/CloudFactory.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/CloudFactory.java
@@ -8,6 +8,8 @@ import org.springframework.cloud.service.ServiceConnectorCreator;
 import org.springframework.cloud.service.ServiceInfo;
 import org.springframework.cloud.util.ServiceLoaderWithExceptionControl;
 
+import static java.lang.String.format;
+
 /**
  * Factory for the cloud.
  *

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/NfsVolumeServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/NfsVolumeServiceInfo.java
@@ -1,0 +1,15 @@
+package org.springframework.cloud.service.common;
+
+import java.io.File;
+import java.util.Collection;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class NfsVolumeServiceInfo extends VolumeServiceInfo {
+
+	public NfsVolumeServiceInfo(String id, Collection<File> mounts) {
+		super(id, mounts);
+	}
+}

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/SmbVolumeServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/SmbVolumeServiceInfo.java
@@ -1,0 +1,15 @@
+package org.springframework.cloud.service.common;
+
+import java.io.File;
+import java.util.Collection;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class SmbVolumeServiceInfo extends VolumeServiceInfo {
+
+	public SmbVolumeServiceInfo(String id, Collection<File> mounts) {
+		super(id, mounts);
+	}
+}

--- a/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/VolumeServiceInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/service/common/VolumeServiceInfo.java
@@ -1,0 +1,31 @@
+package org.springframework.cloud.service.common;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.springframework.cloud.service.BaseServiceInfo;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public abstract class VolumeServiceInfo extends BaseServiceInfo {
+
+    private Collection<File> mounts;
+
+    public VolumeServiceInfo(String id, Collection<File> mounts) {
+        super(id);
+        if (mounts == null) {
+            throw new IllegalArgumentException("Missing mounts");
+        }
+        if (mounts.isEmpty()) {
+            throw new IllegalArgumentException("Missing mounts");
+        }
+        this.mounts = mounts;
+    }
+
+    @ServiceProperty
+    public Collection<File> getVolumeInfos() {
+        return mounts;
+    }
+}

--- a/spring-cloud-core/src/test/java/org/springframework/cloud/service/common/VolumeServiceInfoTest.java
+++ b/spring-cloud-core/src/test/java/org/springframework/cloud/service/common/VolumeServiceInfoTest.java
@@ -1,0 +1,56 @@
+package org.springframework.cloud.service.common;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class VolumeServiceInfoTest {
+	@Test
+	public void nfsAllArgs() {
+		File file1 = new File("/a/path");
+		File file2 = new File("/b/path");
+		Collection<File> volumes = new ArrayList<>();
+		volumes.add(file1);
+		volumes.add(file2);
+
+		NfsVolumeServiceInfo serviceInfo = new NfsVolumeServiceInfo("id", volumes);
+
+		assertEquals(2, serviceInfo.getVolumeInfos().size());
+		assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+	}
+
+	@Test
+	public void smbAllArgs() {
+		File file1 = new File("/a/path");
+		File file2 = new File("/b/path");
+		Collection<File> volumes = new ArrayList<>();
+		volumes.add(file1);
+		volumes.add(file2);
+
+		SmbVolumeServiceInfo serviceInfo = new SmbVolumeServiceInfo("id", volumes);
+
+		assertEquals(2, serviceInfo.getVolumeInfos().size());
+		assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void nullVolumeInfo() {
+		new NfsVolumeServiceInfo("id",  null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void missingVolumeInfo() {
+		new NfsVolumeServiceInfo("id",  new ArrayList<>());
+	}
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/NfsVolumeServiceCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/NfsVolumeServiceCreator.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.service.volumes;
+
+import org.springframework.cloud.service.AbstractServiceConnectorCreator;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.common.NfsVolumeServiceInfo;
+
+import static java.lang.String.format;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class NfsVolumeServiceCreator
+        extends AbstractServiceConnectorCreator<NfsVolumes, NfsVolumeServiceInfo> {
+
+    @Override
+    public NfsVolumes create(NfsVolumeServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {
+        NfsVolumes volumes = new NfsVolumes();
+        volumes.addAll(serviceInfo.getVolumeInfos());
+        return volumes;
+    }
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/NfsVolumes.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/NfsVolumes.java
@@ -1,0 +1,11 @@
+package org.springframework.cloud.service.volumes;
+
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class NfsVolumes extends ArrayList<File> {
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/SmbVolumeServiceCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/SmbVolumeServiceCreator.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.service.volumes;
+
+import org.springframework.cloud.service.AbstractServiceConnectorCreator;
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.common.NfsVolumeServiceInfo;
+import org.springframework.cloud.service.common.SmbVolumeServiceInfo;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class SmbVolumeServiceCreator
+        extends AbstractServiceConnectorCreator<SmbVolumes, SmbVolumeServiceInfo> {
+
+    @Override
+    public SmbVolumes create(SmbVolumeServiceInfo serviceInfo, ServiceConnectorConfig serviceConnectorConfig) {
+        SmbVolumes volumes = new SmbVolumes();
+        volumes.addAll(serviceInfo.getVolumeInfos());
+        return volumes;
+    }
+}

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/SmbVolumes.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/volumes/SmbVolumes.java
@@ -1,0 +1,11 @@
+package org.springframework.cloud.service.volumes;
+
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * @author Paul Warren
+ * @author Dave Walter
+ */
+public class SmbVolumes extends ArrayList<File> {
+}

--- a/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
+++ b/spring-cloud-spring-service-connector/src/main/resources/META-INF/services/org.springframework.cloud.service.ServiceConnectorCreator
@@ -9,3 +9,5 @@ org.springframework.cloud.service.messaging.RabbitConnectionFactoryCreator
 org.springframework.cloud.service.smtp.MailSenderCreator
 org.springframework.cloud.service.relational.SqlServerDataSourceCreator
 org.springframework.cloud.service.column.CassandraClusterCreator
+org.springframework.cloud.service.volumes.NfsVolumeServiceCreator
+org.springframework.cloud.service.volumes.SmbVolumeServiceCreator

--- a/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/volumes/VolumeServiceCreatorTest.java
+++ b/spring-cloud-spring-service-connector/src/test/java/org/springframework/cloud/service/volumes/VolumeServiceCreatorTest.java
@@ -1,0 +1,90 @@
+package org.springframework.cloud.service.volumes;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import org.springframework.cloud.service.ServiceConnectorConfig;
+import org.springframework.cloud.service.common.NfsVolumeServiceInfo;
+import org.springframework.cloud.service.common.SmbVolumeServiceInfo;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class VolumeServiceCreatorTest {
+
+    private NfsVolumeServiceCreator nfsTestCreator = new NfsVolumeServiceCreator();
+    private SmbVolumeServiceCreator smbTestCreator = new SmbVolumeServiceCreator();
+
+    @Test
+    public void nfsVolumeServiceNoConfig() throws Exception {
+        File file1 = new File("/a/path");
+        File file2 = new File("/b/path");
+        Collection<File> volumes = new ArrayList<>();
+        volumes.add(file1);
+        volumes.add(file2);
+
+        NfsVolumeServiceInfo serviceInfo = new NfsVolumeServiceInfo("id", volumes);
+
+        NfsVolumes nfsVolumeServiceInfo = nfsTestCreator.create(serviceInfo, null);
+        assertNotNull(nfsVolumeServiceInfo);
+
+        assertEquals(2, serviceInfo.getVolumeInfos().size());
+        assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+    }
+
+    @Test
+    public void nfsVolumeServiceConfigIsIgnored() throws Exception {
+        File file1 = new File("/a/path");
+        File file2 = new File("/b/path");
+        Collection<File> volumes = new ArrayList<>();
+        volumes.add(file1);
+        volumes.add(file2);
+
+        NfsVolumeServiceInfo serviceInfo = new NfsVolumeServiceInfo("id", volumes);
+
+        NfsVolumes nfsVolumeServiceInfo = nfsTestCreator.create(serviceInfo, new ServiceConnectorConfig() {});
+        assertNotNull(nfsVolumeServiceInfo);
+
+        assertEquals(2, serviceInfo.getVolumeInfos().size());
+        assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+    }
+
+    @Test
+    public void smbVolumeServiceNoConfig() throws Exception {
+        File file1 = new File("/a/path");
+        File file2 = new File("/b/path");
+        Collection<File> volumes = new ArrayList<>();
+        volumes.add(file1);
+        volumes.add(file2);
+
+        SmbVolumeServiceInfo serviceInfo = new SmbVolumeServiceInfo("id", volumes);
+
+        SmbVolumes smbVolumeServiceInfo = smbTestCreator.create(serviceInfo, null);
+        assertNotNull(smbVolumeServiceInfo);
+
+        assertEquals(2, serviceInfo.getVolumeInfos().size());
+        assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+    }
+
+    @Test
+    public void smbVolumeServiceConfigIsIgnored() throws Exception {
+        File file1 = new File("/a/path");
+        File file2 = new File("/b/path");
+        Collection<File> volumes = new ArrayList<>();
+        volumes.add(file1);
+        volumes.add(file2);
+
+        SmbVolumeServiceInfo serviceInfo = new SmbVolumeServiceInfo("id", volumes);
+
+        SmbVolumes smbVolumeServiceInfo = smbTestCreator.create(serviceInfo, new ServiceConnectorConfig() {});
+        assertNotNull(smbVolumeServiceInfo);
+
+        assertEquals(2, serviceInfo.getVolumeInfos().size());
+        assertThat(serviceInfo.getVolumeInfos(), hasItems(file1, file2));
+    }
+}


### PR DESCRIPTION
Hi Folks,

CloudFoundry Persistence team here.  We would like to add support for our Volume Services into your Spring Cloud Connector library.  

When we originally added volume services to CF, we updated the open service broker API to include a [volume mount specification](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#volume-mount-object) for service brokers to follow.  This means that any service broker could issue volume mounts to CF.  Our team manages a number of such brokers including our `nfs` and our `smb` broker that are both GAed in cf-deployment and Pivotal Application Service.  Given the volume_mount specification standard, our original intention for this PR was to have a connector that is able to surface any volume mount, regardless of the broker that issued it, as a bean in the Spring application by, for example, implementing an accept method in a `VolumeServiceInfoCreator` like so:

```
	@Override
	public boolean accept(Map<String, Object> serviceData) {
		return containsVolumeMounts(serviceData);
	}
``` 

However, when multiple volumes are bound to the same application from different services, [this exception](https://github.com/spring-cloud/spring-cloud-connectors/blob/9a376333c45efe0b1a99bee0da5b868ce44201bd/spring-cloud-core/src/main/java/org/springframework/cloud/Cloud.java#L196) is thrown since the `VolumeServiceInfoCreator.accept` matches all volume service infos.  This led us down a path of having to create separate Nfs and Smb everything.  This, therefore, means that if we add additional volume service brokers (as we are very likely to do) we'll have to come back and add them here too.  It feels like there should be a better way but we couldn't see it.  It would be very nice if this PR could be refactored to handle any volume mount and we would be very happy to do so after the appropriate pointers.  If not then we are happy with the current implementation and will add stories to our backlog to update these cloud connectors whenever we add new brokers.  

[#164283399](https://www.pivotaltracker.com/story/show/164283399)

Thanks much,
_Paul

@davewalter @julian-hj