### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-all-services.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-all-services.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:data-source service-name="mysqlDb"/>
 	<cloud:data-source service-name="postDb"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:cloud="http://www.springframework.org/schema/cloud"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+       xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cloud="https://www.springframework.org/schema/cloud"
+       xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
     <bean id="loadBalancingPolicy" class="com.datastax.driver.core.policies.RoundRobinPolicy"/>
     <bean id="reconnectionPolicy" class="com.datastax.driver.core.policies.ConstantReconnectionPolicy">

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:cloud="http://www.springframework.org/schema/cloud"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cloud="https://www.springframework.org/schema/cloud"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 	<cloud:cassandra-session-factory service-name="my-service"/>
 

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-cassandra-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:cloud="http://www.springframework.org/schema/cloud"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cloud="https://www.springframework.org/schema/cloud"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 	<cloud:cassandra-session-factory/>
 

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-with-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 	<cloud:data-source id="no-config" service-name="my-service"/>
 

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:data-source service-name="my-service"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-datasource-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:data-source/>
 	

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-with-connector-type.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-with-connector-type.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:service id="my-service-with-type-with-service-name" 
 				   service-name="my-service" 

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:service service-name="my-service"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-generic-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:service/>
 

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-with-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:mongo-db-factory id="service-connectionPerHost50-maxWait200-WriteConcernNone" service-name="my-service" write-concern="NONE">

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:mongo-db-factory service-name="my-service"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-mongo-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:mongo-db-factory/>
 	

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-properties.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-properties.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:properties id="cloudProperties"/>
 	

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-with-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 	<cloud:rabbit-connection-factory id="service-channelCacheSize200" service-name="my-service">
 		<cloud:rabbit-options channel-cache-size="200"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:rabbit-connection-factory service-name="my-service"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-rabbit-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:rabbit-connection-factory/>
 	

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-with-config.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-with-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 
 	<cloud:redis-connection-factory id="service-pool20-wait200" service-name="my-service">

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-with-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-with-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:redis-connection-factory service-name="my-service"/>

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-without-service-id.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-redis-without-service-id.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 	<cloud:redis-connection-factory/>
 	

--- a/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-scan.xml
+++ b/spring-cloud-spring-service-connector/src/test/resources/org/springframework/cloud/config/xml/cloud-scan.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cloud="http://www.springframework.org/schema/cloud"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:cloud="https://www.springframework.org/schema/cloud"
+	xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	https://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 	
 		 
 	<cloud:service-scan/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 21 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cloud/spring-cloud.xsd with 21 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/spring-cloud.xsd ([https](https://www.springframework.org/schema/cloud/spring-cloud.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 21 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://www.springframework.org/schema/beans with 42 occurrences migrated to:  
  https://www.springframework.org/schema/beans ([https](https://www.springframework.org/schema/beans) result 301).
* [ ] http://www.springframework.org/schema/cloud with 42 occurrences migrated to:  
  https://www.springframework.org/schema/cloud ([https](https://www.springframework.org/schema/cloud) result 301).