### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -446,7 +446,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from VMware's website at
-http://www.vmware.com/download/open_source.html, or by sending a request, 
+https://www.vmware.com/download/open_source.html, or by sending a request, 
 with your name and address to: GoPivotal, Inc., 1900 S. Norfolk Street #125, 
 San Mateo, CA 94403, Attention: General Counsel. All such requests should 
 clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. 

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Spring Cloud Connectors provides a simple abstraction that JVM-based application
 
 == Learn more
 
-See the http://cloud.spring.io/spring-cloud-connectors/[project site] and http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html[current documentation].
+See the https://cloud.spring.io/spring-cloud-connectors/[project site] and https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html[current documentation].
 
 == Build
 
@@ -56,7 +56,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -69,6 +69,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cloud-foundry-connector.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-connectors
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc:
 :toclevels: 3
 
@@ -26,9 +26,9 @@ Below is an example of a `VCAP_SERVICES` entry (edited for brevity).
 "p-rabbitmq": [
  {
   "credentials": {
-   "http_api_uri": "http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api",
+   "http_api_uri": "https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api",
    "http_api_uris": [
-    "http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api"
+    "https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api"
    ],
    "uri": "amqp://ca30db57-a396:ddrnu58423q@12.34.567.89/322e7782-eb1f",
    "uris": [

--- a/docs/src/main/asciidoc/spring-cloud-connectors.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-connectors.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-connectors
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :imagesdir: images
 :toc: left
 :toclevels: 3
@@ -35,7 +35,7 @@ The project contains three major submodules.
 * **Spring Cloud Connectors Core**: The core library, which is both cloud-agnostic and Spring-agnostic. It provides a programmatic entry point for developers who prefer to access cloud services and application information manually. It also provides basic service definitions for several common services (databases, message queues) and an SPI-based extension mechanism for contributing cloud and service connectors.
 * **Spring Cloud Spring Service Connector**: A Spring library that exposes application information, cloud information, and discovered services as Spring beans of the appropriate type (for example, an SQL service will be exposed as a `javax.sql.DataSource` with optional connection pooling).
 * The cloud connectors:
- ** **Spring Cloud Cloud Foundry Connector**: Connector for link:http://cloudfoundry.org/[Cloud Foundry].
+ ** **Spring Cloud Cloud Foundry Connector**: Connector for link:https://cloudfoundry.org/[Cloud Foundry].
  ** **Spring Cloud Heroku Connector**: Connector for link:https://www.heroku.com/[Heroku].
  ** **Spring Cloud local-configuration Connector**: Properties-based connector for manually providing configuration information during development or testing. Allows use of the same Spring Cloud Connectors configuration wiring in all stages of application deployment.
 
@@ -238,7 +238,7 @@ This connector first attempts to read the system properties generally and a syst
 
 ==== Providing a Bootstrap Properties File
 
-To avoid having to manually configure run configurations or test runners with the path to the configuration properties file, the connector can read a templated filename out of the runtime classpath. This file must be named `spring-cloud-bootstrap.properties` and be located at the classpath root. For security, the connector will not attempt to read any service URIs out of the file. If the connector does find the file, it will read the property `spring.cloud.propertiesFile` and link:http://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html[substitute the pattern `${system.property}`] with the appropriate value from the system properties. The most useful option is generally `${user.home}`.
+To avoid having to manually configure run configurations or test runners with the path to the configuration properties file, the connector can read a templated filename out of the runtime classpath. This file must be named `spring-cloud-bootstrap.properties` and be located at the classpath root. For security, the connector will not attempt to read any service URIs out of the file. If the connector does find the file, it will read the property `spring.cloud.propertiesFile` and link:https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html[substitute the pattern `${system.property}`] with the appropriate value from the system properties. The most useful option is generally `${user.home}`.
 
 A configuration properties file specified in the system properties will override any bootstrap file that may be available on the classpath.
 
@@ -272,17 +272,17 @@ You can extend Spring Cloud Connectors in any of three ways:
 
 1. **Cloud platform support.** Out of the box, Spring Cloud Connectors offers support for the Cloud Foundry and Heroku platforms. You can extend Spring Cloud Connectors to provide support for other cloud platforms and providers.
 +
-Spring Cloud Connectors uses the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html[`CloudConnector`] interface to provide cloud platform support. A `CloudConnector` implementation for a particular cloud platform is responsible for detecting when the application is running in that cloud platform, obtaining information about the application from the cloud platform, and obtaining information about the services that are bound to the application.
+Spring Cloud Connectors uses the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html[`CloudConnector`] interface to provide cloud platform support. A `CloudConnector` implementation for a particular cloud platform is responsible for detecting when the application is running in that cloud platform, obtaining information about the application from the cloud platform, and obtaining information about the services that are bound to the application.
 2. **Cloud service support.** You can extend Spring Cloud Connectors to support additional services, including services that are specific to your own environment or application.
 +
 Spring Cloud Connectors uses two interfaces to provide cloud service support:
 +
-* A http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html[`ServiceInfo`] models the information required to connect to the service. In the case of a database service, a `ServiceInfo` implementation might include fields for host, port, database name, username, and password; in the case of a web service, it might include fields for URL and API key.
+* A https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html[`ServiceInfo`] models the information required to connect to the service. In the case of a database service, a `ServiceInfo` implementation might include fields for host, port, database name, username, and password; in the case of a web service, it might include fields for URL and API key.
 +
-* A http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html[`ServiceInfoCreator`] creates `ServiceInfo` objects based on the service information collected by a cloud connector. A `ServiceInfoCreator` implementation is specific to a cloud platform.
-3. **Application framework support.** The <<spring-cloud-spring-service-connector.adoc#,Spring Cloud Spring Service Connector>> creates service connectors with http://projects.spring.io/spring-data/[Spring Data] data types. You can extend Spring Cloud Connectors to provide service connection objects using another framework.
+* A https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html[`ServiceInfoCreator`] creates `ServiceInfo` objects based on the service information collected by a cloud connector. A `ServiceInfoCreator` implementation is specific to a cloud platform.
+3. **Application framework support.** The <<spring-cloud-spring-service-connector.adoc#,Spring Cloud Spring Service Connector>> creates service connectors with https://projects.spring.io/spring-data/[Spring Data] data types. You can extend Spring Cloud Connectors to provide service connection objects using another framework.
 +
-Spring Cloud Connectors uses the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html[`ServiceConnectorCreator`] interface to provide framework support. A `ServiceConnectorCreator` creates service connectors using the service connection information provided by a `ServiceInfo` object.
+Spring Cloud Connectors uses the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html[`ServiceConnectorCreator`] interface to provide framework support. A `ServiceConnectorCreator` creates service connectors using the service connection information provided by a `ServiceInfo` object.
 
 === Adding Cloud Platform Support
 
@@ -297,7 +297,7 @@ See the https://github.com/spring-cloud/spring-cloud-connectors/tree/master/spri
 
 Spring Cloud Connectors uses the https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html[Java SPI] to discover available connectors. 
 
-Your connector class must implement the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html[`CloudConnector`] interface, which includes three methods:
+Your connector class must implement the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html[`CloudConnector`] interface, which includes three methods:
 
 * `boolean isInMatchingCloud()`: Determines whether the connector is operating in the cloud for which it provides support.
 +
@@ -313,7 +313,7 @@ New cloud connectors should list the fully-qualified class name in the provider-
 
 === Adding Service Support
 
-To allow Spring Cloud Connectors to discover a new type of service, create a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html[`ServiceInfo`] class containing the information necessary to connect to the service. If your service can be specified via a URI, extend http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html[`UriBasedServiceInfo`] and provide the URI scheme in a call to the `super` constructor.
+To allow Spring Cloud Connectors to discover a new type of service, create a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html[`ServiceInfo`] class containing the information necessary to connect to the service. If your service can be specified via a URI, extend https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html[`UriBasedServiceInfo`] and provide the URI scheme in a call to the `super` constructor.
 
 The following class will expose information for a `HelloWorldService` available at `helloworld://username:password@host:port/Bonjour`.
 
@@ -334,7 +334,7 @@ public class HelloWorldServiceInfo extends UriBasedServiceInfo {
 }
 ----
 
-After creating the `ServiceInfo` class, you will need to create a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html[`ServiceInfoCreator`] for each cloud platform you want to support. If you are adding service support for a cloud platform already supported by Spring Cloud Connectors, you will probably want to extend the appropriate creator base class(es).
+After creating the `ServiceInfo` class, you will need to create a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html[`ServiceInfoCreator`] for each cloud platform you want to support. If you are adding service support for a cloud platform already supported by Spring Cloud Connectors, you will probably want to extend the appropriate creator base class(es).
 
 [cols="2,8", width="100%"]
 |==================================================================
@@ -373,7 +373,7 @@ A service connector consumes a `ServiceInfo` for a service discovered by the clo
 Service connectors can be tightly bound to the framework whose service objects they are creating. For example, some connectors in the <<_spring_service_connector,Spring Service Connector>> create connection factories defined by Spring Data, for use in building Spring Data templates.
 ====
 
-Your connector class must implement the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html[`ServiceConnectorCreator`] interface, which has three methods:
+Your connector class must implement the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html[`ServiceConnectorCreator`] interface, which has three methods:
 
 * `SC create()`: Creates a service connection object from a given `ServiceInfo` and configuration.
 * `Class<SC> getServiceConnectorType()`: Returns the type of the connection object that will be created.

--- a/docs/src/main/asciidoc/spring-cloud-heroku-connector.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-heroku-connector.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-connectors
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc:
 :toclevels: 3
 

--- a/docs/src/main/asciidoc/spring-cloud-spring-service-connector.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-spring-service-connector.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-connectors
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc:
 :toclevels: 3
 
@@ -9,7 +9,7 @@
 
 The Spring Service Connector is part of the <<spring-cloud-connectors.adoc#,Spring Cloud Connectors>> project.
 
-This library provides `ServiceConnectorCreator` implementations for `javax.sql.DataSource` and various http://projects.spring.io/spring-data/[Spring Data] connector factories. It also provides Java configuration and XML namespace support for connecting to cloud services, accessing cloud services, and accessing application properties.
+This library provides `ServiceConnectorCreator` implementations for `javax.sql.DataSource` and various https://projects.spring.io/spring-data/[Spring Data] connector factories. It also provides Java configuration and XML namespace support for connecting to cloud services, accessing cloud services, and accessing application properties.
 
 == The Java Configuration
 
@@ -24,7 +24,7 @@ The Spring Service Connector Java configuration also offers a way to expose appl
 
 === Creating Service Beans
 
-If you do not wish to extend `AbstractCloudConfig`, you can create your own http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html[`Cloud`] object as an alternative.
+If you do not wish to extend `AbstractCloudConfig`, you can create your own https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html[`Cloud`] object as an alternative.
 
 [source,java]
 ----
@@ -34,7 +34,7 @@ public Cloud cloud() {
 }
 ----
 
-The following example creates a `DataSource` bean (without configuration) using the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html#getSingletonServiceConnector(java.lang.Class,%20org.springframework.cloud.service.ServiceConnectorConfig)[`getSingletonServiceConnector()`] method on `Cloud`.
+The following example creates a `DataSource` bean (without configuration) using the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html#getSingletonServiceConnector(java.lang.Class,%20org.springframework.cloud.service.ServiceConnectorConfig)[`getSingletonServiceConnector()`] method on `Cloud`.
 
 [source,java]
 ----
@@ -50,7 +50,7 @@ public DataSource dataSource() {
 Following examples presume a configuration class which extends `AbstractCloudConfig`.
 ====
 
-The configuration shown in the following example creates a `DataSource` bean that connects to the only relational database service bound to the application (it will fail if there is no such unique service). It also creates a `MongoDbFactory` bean, which again connects to the only MongoDB service bound to the application. (For ways to connect to other services, see the http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html[Javadoc for `AbstractCloudConfig.ServiceConnectionFactory`].)
+The configuration shown in the following example creates a `DataSource` bean that connects to the only relational database service bound to the application (it will fail if there is no such unique service). It also creates a `MongoDbFactory` bean, which again connects to the only MongoDB service bound to the application. (For ways to connect to other services, see the https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html[Javadoc for `AbstractCloudConfig.ServiceConnectionFactory`].)
 
 [source,java]
 ----
@@ -123,7 +123,7 @@ public RabbitConnectionFactory rabbitFactory() {
 }
 ----
 
-To provide configuration for a RabbitMQ service, you can use an overloaded `rabbitConnectionFactory()` variant. The following example connects to the `bunnymq` RabbitMQ service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html[`RabbitConnectionFactoryConfig`], which is initialized with a `channelCacheSize` of 10.
+To provide configuration for a RabbitMQ service, you can use an overloaded `rabbitConnectionFactory()` variant. The following example connects to the `bunnymq` RabbitMQ service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html[`RabbitConnectionFactoryConfig`], which is initialized with a `channelCacheSize` of 10.
 
 [source,java]
 ----
@@ -135,7 +135,7 @@ public RabbitConnectionFactory rabbitFactory() {
 }
 ----
 
-To set properties on a RabbitMQ service, you can use an overloaded variant of `rabbitConnectionFactory()`. The following example connects to the `bunnymq` RabbitMQ service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html[`RabbitConnectionFactoryConfig`], which is initialized with a `HashMap` of property keys and values.
+To set properties on a RabbitMQ service, you can use an overloaded variant of `rabbitConnectionFactory()`. The following example connects to the `bunnymq` RabbitMQ service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html[`RabbitConnectionFactoryConfig`], which is initialized with a `HashMap` of property keys and values.
 
 [source,java]
 ----
@@ -180,7 +180,7 @@ public DataSource dataSource() {
 }
 ----
 
-To provide configuration for a relational database service, you can use an overloaded `dataSource()` variant. The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000.
+To provide configuration for a relational database service, you can use an overloaded `dataSource()` variant. The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000.
 
 [source,java]
 ----
@@ -193,7 +193,7 @@ public DataSource dataSource() {
 }
 ----
 
-To set properties on a relational database service, you can use an overloaded variant of `dataSource()`. The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`]. The `DataSourceConfig` is initialized with a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] (which sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000) and a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html[`ConnectionConfig`] (which sets the `useUnicode` and `characterEncoding` properties).
+To set properties on a relational database service, you can use an overloaded variant of `dataSource()`. The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`]. The `DataSourceConfig` is initialized with a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] (which sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000) and a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html[`ConnectionConfig`] (which sets the `useUnicode` and `characterEncoding` properties).
 
 [source,java]
 ----
@@ -214,9 +214,9 @@ When creating a `DataSource`, the connector prefers any of the following four co
 1. https://commons.apache.org/proper/commons-dbcp/[Apache Commons DBCP and DBCP 2]
 2. Tomcat DBCP
 3. https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC Connection Pool]
-4. http://brettwooldridge.github.io/HikariCP/[HikariCP]
+4. https://brettwooldridge.github.io/HikariCP/[HikariCP]
 
-The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html[`SimpleDriverDataSource`], which does not reuse connections.
+The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html[`SimpleDriverDataSource`], which does not reuse connections.
 
 ====== Reordering Implementation Priority
 
@@ -225,9 +225,9 @@ The connector uses the first of these that is found on the classpath. If none of
 This feature is available only in Spring Cloud Connectors 1.2.1 and later.
 ====
 
-If you would like to reorder the priorities given to supported `DataSource` implementations, you can provide a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`] containing a `List` which uses your own ordering. You can name an implementation either by its full class name or by a string included in its class name.
+If you would like to reorder the priorities given to supported `DataSource` implementations, you can provide a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`] containing a `List` which uses your own ordering. You can name an implementation either by its full class name or by a string included in its class name.
 
-The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a `List` of `DataSource` implementation class names.
+The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a `List` of `DataSource` implementation class names.
 
 [source,java]
 ----
@@ -240,7 +240,7 @@ public DataSource dataSource() {
 }
 ----
 
-The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a `List` of strings contained in `DataSource` implementations&#8217; class names.
+The following example connects to the `my-own-personal-sql` MySQL service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html[`DataSourceConfig`], which is initialized with a `List` of strings contained in `DataSource` implementations&#8217; class names.
 
 [source,java]
 ----
@@ -266,7 +266,7 @@ public MongoDbFactory mongoFactory() {
 }
 ----
 
-To provide configuration for a unique MongoDB service, you can use an overloaded `mongoDbFactory()` variant. The following example connects to the only MongoDB service bound to the application and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html[`MongoDbFactoryConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
+To provide configuration for a unique MongoDB service, you can use an overloaded `mongoDbFactory()` variant. The following example connects to the only MongoDB service bound to the application and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html[`MongoDbFactoryConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
 
 [source,java]
 ----
@@ -289,7 +289,7 @@ public MongoDbFactory mongoFactory() {
 }
 ----
 
-To connect to a specific MongoDB service and provide configuration, you can use an overloaded `mongoDbFactory()` variant. The following example connects to the `mongo-service` MongoDB service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html[`MongoDbFactoryConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
+To connect to a specific MongoDB service and provide configuration, you can use an overloaded `mongoDbFactory()` variant. The following example connects to the `mongo-service` MongoDB service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html[`MongoDbFactoryConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
 
 [source,java]
 ----
@@ -314,7 +314,7 @@ public RedisConnectionFactory redisFactory() {
 }
 ----
 
-To provide configuration for a unique Redis service, you can use an overloaded `redisConnectionFactory()` variant. The following example connects to the only Redis service bound to the application and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html[`PooledServiceConnectorConfig`], which is initialized with a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000.
+To provide configuration for a unique Redis service, you can use an overloaded `redisConnectionFactory()` variant. The following example connects to the only Redis service bound to the application and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html[`PooledServiceConnectorConfig`], which is initialized with a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets a `minPoolSize` of 5, a `maxPoolSize` of 30, and a `maxWaitTime` of 3000.
 
 [source,java]
 ----
@@ -338,7 +338,7 @@ public RedisConnectionFactory redisFactory() {
 }
 ----
 
-To connect to a specific Redis service and provide configuration, you can use an overloaded `redisConnectionFactory()` variant. The following example connects to the `redis-service` Redis service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`], which is initialized with a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
+To connect to a specific Redis service and provide configuration, you can use an overloaded `redisConnectionFactory()` variant. The following example connects to the `redis-service` Redis service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`], which is initialized with a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] that sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200.
 
 [source,java]
 ----
@@ -351,7 +351,7 @@ public RedisConnectionFactory redisFactory() {
 }
 ----
 
-To connect to a specific Redis service and set properties on the service, you can use an overloaded variant of `redisConnectionFactory()`. The following example connects to the `redis-service` Redis service and sets the `timeout` property using a http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`] initialized with a `HashMap` that contains the property key and value.
+To connect to a specific Redis service and set properties on the service, you can use an overloaded variant of `redisConnectionFactory()`. The following example connects to the `redis-service` Redis service and sets the `timeout` property using a https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`] initialized with a `HashMap` that contains the property key and value.
 
 [source,java]
 ----
@@ -365,7 +365,7 @@ public RedisConnectionFactory redisFactory() {
 }
 ----
 
-To connect to a specific Redis service and provide configuration and property values for the service, you can use an overloaded variant of `redisConnectionFactory()`. The following example connects to the `redis-service` Redis service and uses a http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`] initialized with a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] (which sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200) and a `HashMap` (which contains a property key and value) to configure the service and set its `timeout` property.
+To connect to a specific Redis service and provide configuration and property values for the service, you can use an overloaded variant of `redisConnectionFactory()`. The following example connects to the `redis-service` Redis service and uses a https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html[`RedisConnectionFactoryConfig`] initialized with a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html[`PoolConfig`] (which sets `writeConcern` to `NONE`, `connectionsPerHost` to 50, and `maxWaitTime` to 200) and a `HashMap` (which contains a property key and value) to configure the service and set its `timeout` property.
 
 [source,java]
 ----
@@ -393,7 +393,7 @@ public Cluster cluster() {
 }
 ----
 
-To provide configuration for a unique Cassandra service, you can use an overloaded `cluster()` variant. The following example connects to the only Cassandra service bound to the application and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html[`CassandraClusterConfig`] with metrics and JMX reporting disabled.
+To provide configuration for a unique Cassandra service, you can use an overloaded `cluster()` variant. The following example connects to the only Cassandra service bound to the application and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html[`CassandraClusterConfig`] with metrics and JMX reporting disabled.
 
 [source,java]
 ----
@@ -418,7 +418,7 @@ public Cluster cluster() {
 }
 ----
 
-To connect to a specific Cassandra service and provide configuration, you can use an overloaded `cluster()` variant. The following example connects to the `cassandra-service` Cassandra service and supplies configuration using a http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html[`CassandraClusterConfig`] with metrics and JMX reporting disabled.
+To connect to a specific Cassandra service and provide configuration, you can use an overloaded `cluster()` variant. The following example connects to the `cassandra-service` Cassandra service and supplies configuration using a https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html[`CassandraClusterConfig`] with metrics and JMX reporting disabled.
 
 [source,java]
 ----
@@ -434,7 +434,7 @@ public Cluster cluster() {
 
 ==== SMTP
 
-To connect to a unique SMTP service, you can create a service bean using `service()`, providing the service type http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html[`MailSender`]. The following example connects to the only SMTP service bound to the application.
+To connect to a unique SMTP service, you can create a service bean using `service()`, providing the service type https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html[`MailSender`]. The following example connects to the only SMTP service bound to the application.
 
 [source,java]
 ----
@@ -445,7 +445,7 @@ public MailSender mailSender() {
 }
 ----
 
-To connect to a specific SMTP service, you can use an overloaded variant of `service()`, providing the service type http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html[`MailSender`]. The following example connects specifically to the `mail-service` SMTP service.
+To connect to a specific SMTP service, you can use an overloaded variant of `service()`, providing the service type https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html[`MailSender`]. The following example connects specifically to the `mail-service` SMTP service.
 
 [source,java]
 ----
@@ -525,8 +525,8 @@ To use this namespace, add a declaration for it.
 <beans xmlns="http://www.springframework.org/schema/beans"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cloud="http://www.springframework.org/schema/cloud"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
 <!-- <cloud> namespace usage here -->
 ----
@@ -666,9 +666,9 @@ When creating a `DataSource`, the connector prefers any of the following four co
 1. https://commons.apache.org/proper/commons-dbcp/[Apache Commons DBCP and DBCP 2]
 2. Tomcat DBCP
 3. https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat JDBC Connection Pool]
-4. http://brettwooldridge.github.io/HikariCP/[HikariCP]
+4. https://brettwooldridge.github.io/HikariCP/[HikariCP]
 
-The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html[`SimpleDriverDataSource`], which does not reuse connections.
+The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html[`SimpleDriverDataSource`], which does not reuse connections.
 
 ====== Reordering Implementation Priority
 

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorApplicationTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryConnectorApplicationTest.java
@@ -26,7 +26,7 @@ public class CloudFoundryConnectorApplicationTest extends AbstractCloudFoundryCo
 	
 	@Test
 	public void isInMatchingEnvironment() {
-		when(mockEnvironment.getEnvValue("VCAP_APPLICATION")).thenReturn(getApplicationInstanceInfo("myapp", "http://myapp.com"));
+		when(mockEnvironment.getEnvValue("VCAP_APPLICATION")).thenReturn(getApplicationInstanceInfo("myapp", "https://myapp.com"));
 		assertTrue(testCloudConnector.isInMatchingCloud());
 		
 		when(mockEnvironment.getEnvValue("VCAP_APPLICATION")).thenReturn(null);

--- a/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreatorTest.java
+++ b/spring-cloud-cloudfoundry-connector/src/test/java/org/springframework/cloud/cloudfoundry/CloudFoundryServiceInfoCreatorTest.java
@@ -43,8 +43,8 @@ public class CloudFoundryServiceInfoCreatorTest {
 		assertAcceptedWithCredentials(serviceInfoCreator, "url", "amqp://example.com");
 		assertAcceptedWithCredentials(serviceInfoCreator, "url", "amqps://example.com");
 
-		assertNotAcceptedWithCredentials(serviceInfoCreator, "uri", "http://example.com");
-		assertNotAcceptedWithCredentials(serviceInfoCreator, "url", "http://example.com");
+		assertNotAcceptedWithCredentials(serviceInfoCreator, "uri", "https://example.com");
+		assertNotAcceptedWithCredentials(serviceInfoCreator, "url", "https://example.com");
 		assertNotAcceptedWithCredentials(serviceInfoCreator, "otherkey", "amqp://example.com");
 		assertNotAcceptedWithCredentials(serviceInfoCreator, "otherkey", "amqps://example.com");
 	}
@@ -53,15 +53,15 @@ public class CloudFoundryServiceInfoCreatorTest {
 	public void uriKeyMatchesScheme() {
 		DummyServiceInfoCreator serviceInfoCreator = new DummyServiceInfoCreator(new Tags(), "amqp", "amqps");
 
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpUri", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsUri", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpUrl", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsUrl", "http://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpUri", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsUri", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpUrl", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsUrl", "https://example.com");
 
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpuri", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsuri", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpurl", "http://example.com");
-		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsurl", "http://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpuri", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsuri", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpurl", "https://example.com");
+		assertAcceptedWithCredentials(serviceInfoCreator, "amqpsurl", "https://example.com");
 	}
 
 	@Test
@@ -73,15 +73,15 @@ public class CloudFoundryServiceInfoCreatorTest {
 		assertUriRetrieved(serviceInfoCreator, "url", "amqp://example.com");
 		assertUriRetrieved(serviceInfoCreator, "url", "amqps://example.com");
 
-		assertUriRetrieved(serviceInfoCreator, "amqpUri", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpsUri", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpUrl", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpsUrl", "http://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpUri", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpsUri", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpUrl", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpsUrl", "https://example.com");
 
-		assertUriRetrieved(serviceInfoCreator, "amqpuri", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpsuri", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpurl", "http://example.com");
-		assertUriRetrieved(serviceInfoCreator, "amqpsurl", "http://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpuri", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpsuri", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpurl", "https://example.com");
+		assertUriRetrieved(serviceInfoCreator, "amqpsurl", "https://example.com");
 	}
 
 

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-missing-required-fields.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-missing-required-fields.json
@@ -2,7 +2,7 @@
   "p-dse-cassandra-acceptance": [
 	{
 	  "credentials": {
-		"opscenter_url": "http://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html"
+		"opscenter_url": "https://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html"
 	  },
 	  "label": "p-dse-cassandra-acceptance",
 	  "name": "mydse",

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-service.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-service.json
@@ -7,7 +7,7 @@
 		  "1.2.3.4",
 		  "5.6.7.8"
 		],
-		"opscenter_url": "http://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html"
+		"opscenter_url": "https://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html"
 	  },
 	  "label": "p-dse-cassandra-acceptance",
 	  "name": "mydse",

--- a/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-with-credentials.json
+++ b/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-cassandra-with-credentials.json
@@ -6,7 +6,7 @@
 		"node_ips": [
 		  "1.2.3.4"
 		],
-		"opscenter_url": "http://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html",
+		"opscenter_url": "https://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html",
 		"password": "pass",
 		"username": "user"
 	  },

--- a/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/MysqlDataSourceCreator.java
+++ b/spring-cloud-spring-service-connector/src/main/java/org/springframework/cloud/service/relational/MysqlDataSourceCreator.java
@@ -12,7 +12,7 @@ public class MysqlDataSourceCreator extends DataSourceCreator<MysqlServiceInfo> 
 	public static final String[] DRIVERS = new String[]{"org.mariadb.jdbc.Driver", "com.mysql.jdbc.Driver"};
 	/**
 	 * Validation query obtained from the MySQL reference manual:
-	 * http://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html
+	 * https://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html
 	 */
 	public static final String VALIDATION_QUERY = "/* ping */ SELECT 1";
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api (UnknownHostException) with 2 occurrences migrated to:  
  https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api ([https](https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api) result UnknownHostException).
* [ ] http://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html (UnknownHostException) with 3 occurrences migrated to:  
  https://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html ([https](https://datastax-opscenter-cassandra.cf-app.com/opscenter/index.html) result UnknownHostException).
* [ ] http://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html (301) with 1 occurrences migrated to:  
  https://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html ([https](https://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html) result 404).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://brettwooldridge.github.io/HikariCP/ with 2 occurrences migrated to:  
  https://brettwooldridge.github.io/HikariCP/ ([https](https://brettwooldridge.github.io/HikariCP/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/ ([https](https://cloud.spring.io/spring-cloud-connectors/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).
* [ ] http://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html with 1 occurrences migrated to:  
  https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html ([https](https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html with 3 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html with 5 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html with 5 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html) result 200).
* [ ] http://example.com with 18 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://github.com/ with 4 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cloud/spring-cloud.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/spring-cloud.xsd ([https](https://www.springframework.org/schema/cloud/spring-cloud.xsd) result 200).
* [ ] http://www.vmware.com/download/open_source.html with 1 occurrences migrated to:  
  https://www.vmware.com/download/open_source.html ([https](https://www.vmware.com/download/open_source.html) result 200).
* [ ] http://cloudfoundry.org/ with 1 occurrences migrated to:  
  https://cloudfoundry.org/ ([https](https://cloudfoundry.org/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://raw.github.com/ with 4 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://myapp.com with 1 occurrences migrated to:  
  https://myapp.com ([https](https://myapp.com) result 302).

# Ignored
These URLs were intentionally ignored.

* http://username:password@rabbitmq-broker:12345/api with 2 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/cloud with 4 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences