### PR TITLE
URL Cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "github-pages"
 gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (4.2.6)
       i18n (~> 0.7)

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Introduction
 
-Spring's project pages are based on [Jekyll](http://jekyllrb.com) and [GitHub Pages](http://pages.github.com/). This means that each project's website is stored within the project repo, in a special branch called "gh-pages". In order to keep everything looking similar across the many individual Spring projects, common elements of the Jekyll site layout, css, etc are stored in [a shared gh-pages repository](http://github.com/spring-projects/gh-pages). If you're seeing this README in the gh-pages branch of an actual Spring project, that's because this file, along with all the other common files get merged periodically into each project.
+Spring's project pages are based on [Jekyll](https://jekyllrb.com) and [GitHub Pages](https://pages.github.com/). This means that each project's website is stored within the project repo, in a special branch called "gh-pages". In order to keep everything looking similar across the many individual Spring projects, common elements of the Jekyll site layout, css, etc are stored in [a shared gh-pages repository](https://github.com/spring-projects/gh-pages). If you're seeing this README in the gh-pages branch of an actual Spring project, that's because this file, along with all the other common files get merged periodically into each project.
 
 This approach may sound a little funky (and it is), but it's way better than the misery of Git submodules. In fact, it's actually pretty easy. If you're just getting started, then follow the directions immediately below. If you're needing a refresher on how to keep things up to date, then head to the section at the bottom on "keeping up to date".
 
@@ -123,7 +123,7 @@ Once you're satisified with your edits, commit your changes and push the `gh-pag
 
 ## View your site live on the web
 
-That's it! After not more than a few minutes, you should be able to see your site at http://spring-projects.github.io/{your-spring-project}
+That's it! After not more than a few minutes, you should be able to see your site at https://spring-projects.github.io/{your-spring-project}
 
 
 # How to keep common gh-pages content up to date

--- a/_includes/download_widget.md
+++ b/_includes/download_widget.md
@@ -10,8 +10,8 @@ Download
         <p>The recommended way to get started using <code>{{ site.project }}</code> in
         your project is with a dependency management system &ndash; the snippet below can
         be copied and pasted into your build. Need help? See our getting started guides
-        on building with <a href="http://spring.io/guides/gs/maven/">Maven</a> and
-        <a href="http://spring.io/guides/gs/gradle/">Gradle</a>.
+        on building with <a href="https://spring.io/guides/gs/maven/">Maven</a> and
+        <a href="https://spring.io/guides/gs/gradle/">Gradle</a>.
         </p>
         <div class="js-download-maven-widget"></div>
         </div>

--- a/_sample-pages/project.html
+++ b/_sample-pages/project.html
@@ -14,7 +14,7 @@ badges:
       icon: github
 
     - name: Issues (JIRA)
-      url:  http://jira.springsource.org/browse/DATAJPA
+      url:  https://jira.springsource.org/browse/DATAJPA
       icon: tracking
 
     - name: CI (Bamboo)
@@ -22,11 +22,11 @@ badges:
       icon: ci
 
     - name: Forum
-      url:  http://forum.spring.io/forum/spring-projects/data
+      url:  https://forum.spring.io/forum/spring-projects/data
       icon: forum
 
     - name: StackOverflow
-      url:  http://stackoverflow.com/questions/tagged/spring-data-jpa
+      url:  https://stackoverflow.com/questions/tagged/spring-data-jpa
       icon: stackoverflow
 
     - name: Metrics (SonarQube)

--- a/_sample-pages/project_group.html
+++ b/_sample-pages/project_group.html
@@ -16,42 +16,42 @@ and developers that are behind these exciting technologies.
 {% capture project_description %}
 Hearts of the stars brain is the seed of intelligence consciousness extraplanetary shores of the cosmic ocean! As a patch of light paroxysm of global death? Inconspicuous motes of rock and gas.
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
 
 {% capture project_description %}
 This is Apache Hadoop Hadoop!
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
 
 {% capture project_description %}
 Hearts of the stars brain is the seed of intelligence consciousness extraplanetary shores of the cosmic ocean! As a patch of light paroxysm of global death? Inconspicuous motes of rock and gas.
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
 
 {% capture project_description %}
 This is Apache Hadoop Hadoop!
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
 
 {% capture project_description %}
 Hearts of the stars brain is the seed of intelligence consciousness extraplanetary shores of the cosmic ocean! As a patch of light paroxysm of global death? Inconspicuous motes of rock and gas.
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
 
 {% capture project_description %}
 This is Apache Hadoop Hadoop!
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
 
 {% capture project_description %}
 Hearts of the stars brain is the seed of intelligence consciousness extraplanetary shores of the cosmic ocean! As a patch of light paroxysm of global death? Inconspicuous motes of rock and gas.
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/sprinframework" project_title="Spring Framework" project_description=project_description %}
 
 {% capture project_description %}
 This is Apache Hadoop Hadoop!
 {% endcapture %}
-{% include project_block.md site_url="http://www.spring.io" repo_url="http://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
+{% include project_block.md site_url="https://www.spring.io" repo_url="https://github.com/spring_hadoop" project_title="Apache Hadoop" project_description=project_description %}
 
 {% endcapture %}
 

--- a/bootstrap/css/bootstrap-select.css
+++ b/bootstrap/css/bootstrap-select.css
@@ -1,6 +1,6 @@
 /*!
  * bootstrap-select v1.1.1
- * http://silviomoreto.github.io/bootstrap-select/
+ * https://silviomoreto.github.io/bootstrap-select/
  *
  * Copyright 2013 bootstrap-select
  * Licensed under the MIT license

--- a/bootstrap/js/bootstrap-select.js
+++ b/bootstrap/js/bootstrap-select.js
@@ -1,6 +1,6 @@
 /*!
  * bootstrap-select v1.1.1
- * http://silviomoreto.github.io/bootstrap-select/
+ * https://silviomoreto.github.io/bootstrap-select/
  *
  * Copyright 2013 bootstrap-select
  * Licensed under the MIT license

--- a/bootstrap/js/bootstrap.js
+++ b/bootstrap/js/bootstrap.js
@@ -1,6 +1,6 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#transitions
+ * https://twitter.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -23,7 +23,7 @@
   "use strict"; // jshint ;_;
 
 
-  /* CSS TRANSITION SUPPORT (http://www.modernizr.com/)
+  /* CSS TRANSITION SUPPORT (https://www.modernizr.com/)
    * ======================================================= */
 
   $(function () {
@@ -59,7 +59,7 @@
 
 }(window.jQuery);/* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * https://twitter.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -157,7 +157,7 @@
 
 }(window.jQuery);/* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#buttons
+ * https://twitter.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -261,7 +261,7 @@
 
 }(window.jQuery);/* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#carousel
+ * https://twitter.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -467,7 +467,7 @@
 
 }(window.jQuery);/* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#collapse
+ * https://twitter.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -633,7 +633,7 @@
 
 }(window.jQuery);/* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#dropdowns
+ * https://twitter.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -802,7 +802,7 @@
 }(window.jQuery);
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#modals
+ * https://twitter.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1049,7 +1049,7 @@
 }(window.jQuery);
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tooltips
+ * https://twitter.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
@@ -1410,7 +1410,7 @@
 }(window.jQuery);
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#popovers
+ * https://twitter.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1524,7 +1524,7 @@
 }(window.jQuery);
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
+ * https://twitter.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1685,7 +1685,7 @@
 
 }(window.jQuery);/* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * https://twitter.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1828,7 +1828,7 @@
 
 }(window.jQuery);/* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * https://twitter.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -2163,7 +2163,7 @@
 }(window.jQuery);
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#affix
+ * https://twitter.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/cloudfoundry-connector.html
+++ b/cloudfoundry-connector.html
@@ -8,7 +8,7 @@
 <title>Untitled</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -409,7 +409,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-/* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
+/* Stylesheet for CodeRay to match GitHub theme | MIT License | https://foundation.zurb.com */
 /*pre.CodeRay {background-color:#f7f7f8;}*/
 .CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
 .CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}

--- a/css/main.css.css
+++ b/css/main.css.css
@@ -427,7 +427,7 @@ input.floating-input:focus {
 
 .bottom-slide--container .bottom-slider--image {
     background-image:
-        url("http://imgs.mi9.com/uploads/landscape/2101/beautiful-leaf-wallpapers_1280x960_28083.jpg");
+        url("https://imgs.mi9.com/uploads/landscape/2101/beautiful-leaf-wallpapers_1280x960_28083.jpg");
     background-size: cover;
     height: 137px;
     transition: all 0.33s;

--- a/font-awesome/css/font-awesome-ie7.css
+++ b/font-awesome/css/font-awesome-ie7.css
@@ -3,25 +3,25 @@
  *  the iconic font designed for Bootstrap
  *  ------------------------------------------------------------------------------
  *  The full suite of pictographic icons, examples, and documentation can be
- *  found at http://fontawesome.io.  Stay up to date on Twitter at
- *  http://twitter.com/fontawesome.
+ *  found at https://fontawesome.com?from=io.  Stay up to date on Twitter at
+ *  https://twitter.com/fontawesome.
  *
  *  License
  *  ------------------------------------------------------------------------------
  *  - The Font Awesome font is licensed under SIL OFL 1.1 -
- *    http://scripts.sil.org/OFL
+ *    https://scripts.sil.org/OFL
  *  - Font Awesome CSS, LESS, and SASS files are licensed under MIT License -
- *    http://opensource.org/licenses/mit-license.html
+ *    https://opensource.org/licenses/mit-license.html
  *  - Font Awesome documentation licensed under CC BY 3.0 -
- *    http://creativecommons.org/licenses/by/3.0/
+ *    https://creativecommons.org/licenses/by/3.0/
  *  - Attribution is no longer required in Font Awesome 3.0, but much appreciated:
- *    "Font Awesome by Dave Gandy - http://fontawesome.io"
+ *    "Font Awesome by Dave Gandy - https://fontawesome.com?from=io"
  *
  *  Author - Dave Gandy
  *  ------------------------------------------------------------------------------
  *  Email: dave@fontawesome.io
- *  Twitter: http://twitter.com/byscuits
- *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
+ *  Twitter: https://twitter.com/byscuits
+ *  Work: Lead Product Designer @ Kyruus - https://www.kyruus.com/
  */
 .icon-large {
   font-size: 1.3333333333333333em;

--- a/font-awesome/css/font-awesome.css
+++ b/font-awesome/css/font-awesome.css
@@ -3,25 +3,25 @@
  *  the iconic font designed for Bootstrap
  *  ------------------------------------------------------------------------------
  *  The full suite of pictographic icons, examples, and documentation can be
- *  found at http://fontawesome.io.  Stay up to date on Twitter at
- *  http://twitter.com/fontawesome.
+ *  found at https://fontawesome.com?from=io.  Stay up to date on Twitter at
+ *  https://twitter.com/fontawesome.
  *
  *  License
  *  ------------------------------------------------------------------------------
  *  - The Font Awesome font is licensed under SIL OFL 1.1 -
- *    http://scripts.sil.org/OFL
+ *    https://scripts.sil.org/OFL
  *  - Font Awesome CSS, LESS, and SASS files are licensed under MIT License -
- *    http://opensource.org/licenses/mit-license.html
+ *    https://opensource.org/licenses/mit-license.html
  *  - Font Awesome documentation licensed under CC BY 3.0 -
- *    http://creativecommons.org/licenses/by/3.0/
+ *    https://creativecommons.org/licenses/by/3.0/
  *  - Attribution is no longer required in Font Awesome 3.0, but much appreciated:
- *    "Font Awesome by Dave Gandy - http://fontawesome.io"
+ *    "Font Awesome by Dave Gandy - https://fontawesome.com?from=io"
  *
  *  Author - Dave Gandy
  *  ------------------------------------------------------------------------------
  *  Email: dave@fontawesome.io
- *  Twitter: http://twitter.com/byscuits
- *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
+ *  Twitter: https://twitter.com/byscuits
+ *  Work: Lead Product Designer @ Kyruus - https://www.kyruus.com/
  */
 /* FONT PATH
  * -------------------------- */

--- a/heroku-connector.html
+++ b/heroku-connector.html
@@ -8,7 +8,7 @@
 <title>Untitled</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -409,7 +409,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-/* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
+/* Stylesheet for CodeRay to match GitHub theme | MIT License | https://foundation.zurb.com */
 /*pre.CodeRay {background-color:#f7f7f8;}*/
 .CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
 .CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ badges:
       icon: ci
 
     - name: StackOverflow
-      url:  http://stackoverflow.com/questions/tagged/spring-cloud-connectors
+      url:  https://stackoverflow.com/questions/tagged/spring-cloud-connectors
       icon: stackoverflow
 
 
@@ -59,10 +59,10 @@ Spring Cloud Connectors focuses on providing a good out-of-the-box experience fo
 
 ### Constituent Projects
 
-* [Spring Cloud Connectors Core](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_spring_cloud_connectors_core): Core library. Cloud-agnostic, and does not rely on Spring; provides an entry point for application developers who choose to access cloud services and application information programmatically, and provides an extension mechanism for contributing cloud connectors and service connector creators.
-* [Spring Cloud Service Connector](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html): Library that provides service connector creators for `javax.sql.DataSource` and various connection factories from Spring Data projects.
-* [Cloud Foundry Connector](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html): Cloud connector for Cloud Foundry.
-* [Heroku Connector](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-heroku-connector.html): Cloud connector for Heroku.
+* [Spring Cloud Connectors Core](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_spring_cloud_connectors_core): Core library. Cloud-agnostic, and does not rely on Spring; provides an entry point for application developers who choose to access cloud services and application information programmatically, and provides an extension mechanism for contributing cloud connectors and service connector creators.
+* [Spring Cloud Service Connector](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html): Library that provides service connector creators for `javax.sql.DataSource` and various connection factories from Spring Data projects.
+* [Cloud Foundry Connector](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html): Cloud connector for Cloud Foundry.
+* [Heroku Connector](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-heroku-connector.html): Cloud connector for Heroku.
 
 
 <span id="quick-start"></span>
@@ -70,7 +70,7 @@ Spring Cloud Connectors focuses on providing a good out-of-the-box experience fo
 
 {% include download_widget.md %}
 
-Then if you are working with a Spring application, follow instructions in [Spring Cloud Spring Service Connector](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html). If you aren't using Spring, take a look at [Spring Cloud Connectors Core](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_spring_cloud_connectors_core).
+Then if you are working with a Spring application, follow instructions in [Spring Cloud Spring Service Connector](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html). If you aren't using Spring, take a look at [Spring Cloud Connectors Core](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html#_spring_cloud_connectors_core).
 
 {{ community_extensions | markdownify }}
 

--- a/js/backbone.js
+++ b/js/backbone.js
@@ -3,7 +3,7 @@
 //     (c) 2010-2013 Jeremy Ashkenas, DocumentCloud Inc.
 //     Backbone may be freely distributed under the MIT license.
 //     For all details and documentation:
-//     http://backbonejs.org
+//     https://backbonejs.org
 
 (function(){
 
@@ -1298,7 +1298,7 @@
   // ----------------
 
   // Handles cross-browser history management, based on either
-  // [pushState](http://diveintohtml5.info/history.html) and real URLs, or
+  // [pushState](https://diveintohtml5.info/history.html) and real URLs, or
   // [onhashchange](https://developer.mozilla.org/en-US/docs/DOM/window.onhashchange)
   // and URL fragments. If the browser supports neither (old IE, natch),
   // falls back to polling.

--- a/js/jquery.js
+++ b/js/jquery.js
@@ -1,13 +1,13 @@
 /*!
  * jQuery JavaScript Library v1.10.1
- * http://jquery.com/
+ * https://jquery.com/
  *
  * Includes Sizzle.js
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  *
  * Copyright 2005, 2013 jQuery Foundation, Inc. and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Date: 2013-05-30T21:49Z
  */
@@ -561,7 +561,7 @@ jQuery.extend({
 
 			if ( data ) {
 				// Make sure the incoming data is actual JSON
-				// Logic borrowed from http://json.org/json2.js
+				// Logic borrowed from https://json.org/json2.js
 				if ( rvalidchars.test( data.replace( rvalidescape, "@" )
 					.replace( rvalidtokens, "]" )
 					.replace( rvalidbraces, "")) ) {
@@ -602,7 +602,7 @@ jQuery.extend({
 
 	// Evaluates a script in a global context
 	// Workarounds based on findings by Jim Driscoll
-	// http://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context
+	// https://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context
 	globalEval: function( data ) {
 		if ( data && jQuery.trim( data ) ) {
 			// We use execScript on Internet Explorer
@@ -921,7 +921,7 @@ jQuery.ready.promise = function( obj ) {
 
 		// Catch cases where $(document).ready() is called after the browser event has already occurred.
 		// we once tried to use readyState "interactive" here, but it caused issues like the one
-		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
+		// discovered by ChrisS here: https://bugs.jquery.com/ticket/12282#comment:15
 		if ( document.readyState === "complete" ) {
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
 			setTimeout( jQuery.ready );
@@ -1001,11 +1001,11 @@ function isArraylike( obj ) {
 rootjQuery = jQuery(document);
 /*!
  * Sizzle CSS Selector Engine v1.9.4-pre
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  *
  * Copyright 2013 jQuery Foundation, Inc. and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Date: 2013-05-27
  */
@@ -1069,17 +1069,17 @@ var i,
 
 	// Regular expressions
 
-	// Whitespace characters http://www.w3.org/TR/css3-selectors/#whitespace
+	// Whitespace characters https://www.w3.org/TR/css3-selectors/#whitespace
 	whitespace = "[\\x20\\t\\r\\n\\f]",
-	// http://www.w3.org/TR/css3-syntax/#characters
+	// https://www.w3.org/TR/css3-syntax/#characters
 	characterEncoding = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
 
 	// Loosely modeled on CSS identifier characters
-	// An unquoted value should be a CSS identifier http://www.w3.org/TR/css3-selectors/#attribute-selectors
-	// Proper syntax: http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+	// An unquoted value should be a CSS identifier https://www.w3.org/TR/css3-selectors/#attribute-selectors
+	// Proper syntax: https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
 	identifier = characterEncoding.replace( "w", "w#" ),
 
-	// Acceptable operators http://www.w3.org/TR/selectors/#attribute-selectors
+	// Acceptable operators https://www.w3.org/TR/selectors/#attribute-selectors
 	attributes = "\\[" + whitespace + "*(" + characterEncoding + ")" + whitespace +
 		"*(?:([*^$|!~]?=)" + whitespace + "*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|(" + identifier + ")|)|)" + whitespace + "*\\]",
 
@@ -1129,7 +1129,7 @@ var i,
 
 	rescape = /'|\\/g,
 
-	// CSS escapes http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
+	// CSS escapes https://www.w3.org/TR/CSS21/syndata.html#escaped-characters
 	runescape = new RegExp( "\\\\([\\da-f]{1,6}" + whitespace + "?|(" + whitespace + ")|.)", "ig" ),
 	funescape = function( _, escaped, escapedWhitespace ) {
 		var high = "0x" + escaped - 0x10000;
@@ -1376,7 +1376,7 @@ function boolHandler( elem, name ) {
 
 /**
  * Fetches attributes without interpolation
- * http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+ * https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
  * @param {Element} elem
  * @param {String} name
  */
@@ -1653,7 +1653,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 	// We allow this because of a bug in IE8/9 that throws an error
 	// whenever `document.activeElement` is accessed on an iframe
 	// So, we allow :focus to pass through QSA all the time to avoid the IE error
-	// See http://bugs.jquery.com/ticket/13378
+	// See https://bugs.jquery.com/ticket/13378
 	rbuggyQSA = [];
 
 	if ( (support.qsa = isNative(doc.querySelectorAll)) ) {
@@ -1664,7 +1664,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// This is to test IE's treatment of not explicitly
 			// setting a boolean content attribute,
 			// since its presence should be enough
-			// http://bugs.jquery.com/ticket/12359
+			// https://bugs.jquery.com/ticket/12359
 			div.innerHTML = "<select><option selected=''></option></select>";
 
 			// Support: IE8
@@ -1674,7 +1674,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			}
 
 			// Webkit/Opera - :checked should return selected option elements
-			// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+			// https://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
 			// IE8 throws error here and will not see later tests
 			if ( !div.querySelectorAll(":checked").length ) {
 				rbuggyQSA.push(":checked");
@@ -2219,7 +2219,7 @@ Expr = Sizzle.selectors = {
 
 		"PSEUDO": function( pseudo, argument ) {
 			// pseudo-class names are case-insensitive
-			// http://www.w3.org/TR/selectors/#pseudo-classes
+			// https://www.w3.org/TR/selectors/#pseudo-classes
 			// Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
 			// Remember that setFilters inherits from pseudos
 			var args,
@@ -2303,7 +2303,7 @@ Expr = Sizzle.selectors = {
 		// or beginning with the identifier C immediately followed by "-".
 		// The matching of C against the element's language value is performed case-insensitively.
 		// The identifier C does not have to be a valid language name."
-		// http://www.w3.org/TR/selectors/#lang-pseudo
+		// https://www.w3.org/TR/selectors/#lang-pseudo
 		"lang": markFunction( function( lang ) {
 			// lang value must be a valid identifier
 			if ( !ridentifier.test(lang || "") ) {
@@ -2350,7 +2350,7 @@ Expr = Sizzle.selectors = {
 
 		"checked": function( elem ) {
 			// In CSS3, :checked should return both checked and selected elements
-			// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+			// https://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
 			var nodeName = elem.nodeName.toLowerCase();
 			return (nodeName === "input" && !!elem.checked) || (nodeName === "option" && !!elem.selected);
 		},
@@ -2367,7 +2367,7 @@ Expr = Sizzle.selectors = {
 
 		// Contents
 		"empty": function( elem ) {
-			// http://www.w3.org/TR/selectors/#empty-pseudo
+			// https://www.w3.org/TR/selectors/#empty-pseudo
 			// :empty is only affected by element nodes and content nodes(including text(3), cdata(4)),
 			//   not comment, processing instructions, or others
 			// Thanks to Diego Perini for the nodeName shortcut
@@ -4024,7 +4024,7 @@ jQuery.fn.extend({
 		});
 	},
 	// Based off of the plugin by Clint Helfers, with permission.
-	// http://blindsignals.com/index.php/2009/07/jquery-delay/
+	// http://blindsignals.com
 	delay: function( time, type ) {
 		time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
 		type = type || "fx";
@@ -4501,7 +4501,7 @@ jQuery.extend({
 		tabIndex: {
 			get: function( elem ) {
 				// elem.tabIndex doesn't always return the correct value when it hasn't been explicitly set
-				// http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
+				// https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
 				// Use proper attribute retrieval(#12072)
 				var tabindex = jQuery.find.attr( elem, "tabindex" );
 
@@ -4641,7 +4641,7 @@ if ( !getSetAttribute ) {
 
 
 // Some attributes require a special call on IE
-// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+// https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
 if ( !jQuery.support.hrefNormalized ) {
 	// href/src property should get the full normalized URL (#10299/#12915)
 	jQuery.each([ "href", "src" ], function( i, name ) {
@@ -5413,7 +5413,7 @@ jQuery.Event = function( src, props ) {
 };
 
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
-// http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+// https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
 	isDefaultPrevented: returnFalse,
 	isPropagationStopped: returnFalse,
@@ -6516,7 +6516,7 @@ jQuery.extend({
 		if ( (!jQuery.support.noCloneEvent || !jQuery.support.noCloneChecked) &&
 				(elem.nodeType === 1 || elem.nodeType === 11) && !jQuery.isXMLDoc(elem) ) {
 
-			// We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
+			// We eschew Sizzle here for performance reasons: https://jsperf.com/getall-vs-sizzle/2
 			destElements = getAll( clone );
 			srcElements = getAll( elem );
 
@@ -7120,7 +7120,7 @@ if ( window.getComputedStyle ) {
 			// A tribute to the "awesome hack by Dean Edwards"
 			// Chrome < 17 and Safari 5.0 uses "computed value" instead of "used value" for margin-right
 			// Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
-			// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
+			// this is against the CSSOM draft spec: https://dev.w3.org/csswg/cssom/#resolved-values
 			if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
 
 				// Remember the original values
@@ -8729,7 +8729,7 @@ if ( xhrSupported ) {
 
 						// Firefox throws exceptions when accessing properties
 						// of an xhr when a network error occurred
-						// http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
+						// https://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
 						try {
 
 							// Was never called and is aborted or complete

--- a/js/test/SpecRunner.html
+++ b/js/test/SpecRunner.html
@@ -4,7 +4,7 @@ title: Your Project Name Here
 ---
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-        "http://www.w3.org/TR/html4/loose.dtd">
+        "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
     <title>Jasmine Spec Runner</title>

--- a/js/test/lib/support/mock-ajax.js
+++ b/js/test/lib/support/mock-ajax.js
@@ -4,9 +4,9 @@
 
  Supports both Prototype.js and jQuery.
 
- http://github.com/pivotal/jasmine-ajax
+ https://github.com/pivotal/jasmine-ajax
 
- Jasmine Home page: http://pivotal.github.com/jasmine
+ Jasmine Home page: https://pivotal.github.com/jasmine
 
  Copyright (c) 2008-2010 Pivotal Labs
 

--- a/js/test/spec/QuickStartWidgetSpec.js
+++ b/js/test/spec/QuickStartWidgetSpec.js
@@ -6,18 +6,18 @@ describe("QuickStartWidget", function () {
       var project = new Spring.Project({
         "id": "spring-data-jpa",
         "name": "Spring Data JPA",
-        "repoUrl": "http://github.com/SpringSource/spring-data-jpa",
-        "siteUrl": "http://projects.spring.io/spring-data-jpa",
+        "repoUrl": "https://github.com/SpringSource/spring-data-jpa",
+        "siteUrl": "https://projects.spring.io/spring-data-jpa",
         "projectReleases": [
           {
-            "refDocUrl": "http://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/reference/html/",
-            "apiDocUrl": "http://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/api/",
+            "refDocUrl": "https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/reference/html/",
+            "apiDocUrl": "https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/api/",
             "groupId": "org.springframework.data",
             "artifactId": "spring-data-jpa",
             "repository": {
               "id": "spring-milestones",
               "name": "Spring Milestones",
-              "url": "http://repo.spring.io/milestone",
+              "url": "https://repo.spring.io/milestone",
               "snapshotsEnabled": false
             },
             "version": "1.4.0.RC1",
@@ -28,8 +28,8 @@ describe("QuickStartWidget", function () {
             "versionDisplayName": "1.4.0.RC1"
           },
           {
-            "refDocUrl": "http://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/reference/html/",
-            "apiDocUrl": "http://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/api/",
+            "refDocUrl": "https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/reference/html/",
+            "apiDocUrl": "https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/api/",
             "groupId": "org.springframework.data",
             "artifactId": "spring-data-jpa",
             "repository": null,
@@ -73,7 +73,7 @@ describe("QuickStartWidget", function () {
 
           expect($('#maven_widget')).toContainText("spring-milestones");
           expect($('#maven_widget')).toContainText("Spring Milestones");
-          expect($('#maven_widget')).toContainText("http://repo.spring.io/milestone");
+          expect($('#maven_widget')).toContainText("https://repo.spring.io/milestone");
           expect($('#maven_widget')).toContainText("false");
       });
 
@@ -83,7 +83,7 @@ describe("QuickStartWidget", function () {
           expect($('#maven_widget')).not.toContainText("repository");
           expect($('#maven_widget')).not.toContainText("spring-milestones");
           expect($('#maven_widget')).not.toContainText("Spring Milestones");
-          expect($('#maven_widget')).not.toContainText("http://repo.spring.io/milestone");
+          expect($('#maven_widget')).not.toContainText("https://repo.spring.io/milestone");
           expect($('#maven_widget')).not.toContainText("false");
       });
     });
@@ -102,7 +102,7 @@ describe("QuickStartWidget", function () {
         $('#jasmine_content select').val(0).change();
 
         expect($('#maven_widget')).toContainText("repositories");
-        expect($('#maven_widget')).toContainText("http://repo.spring.io/milestone");
+        expect($('#maven_widget')).toContainText("https://repo.spring.io/milestone");
       });
     });
   });

--- a/js/underscore.js
+++ b/js/underscore.js
@@ -1,5 +1,5 @@
 //     Underscore.js 1.5.1
-//     http://underscorejs.org
+//     https://underscorejs.org
 //     (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
@@ -554,7 +554,7 @@
 
   // Generate an integer Array containing an arithmetic progression. A port of
   // the native Python `range()` function. See
-  // [the Python documentation](http://docs.python.org/library/functions.html#range).
+  // [the Python documentation](https://docs.python.org/library/functions.html#range).
   _.range = function(start, stop, step) {
     if (arguments.length <= 1) {
       stop = start || 0;
@@ -844,7 +844,7 @@
   // Internal recursive comparison function for `isEqual`.
   var eq = function(a, b, aStack, bStack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.
-    // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
+    // See the [Harmony `egal` proposal](https://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) return a !== 0 || 1 / a == 1 / b;
     // A strict comparison is necessary because `null == undefined`.
     if (a == null || b == null) return a === b;

--- a/localconfig-connector.html
+++ b/localconfig-connector.html
@@ -8,7 +8,7 @@
 <title>Untitled</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -409,7 +409,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-/* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
+/* Stylesheet for CodeRay to match GitHub theme | MIT License | https://foundation.zurb.com */
 /*pre.CodeRay {background-color:#f7f7f8;}*/
 .CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
 .CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}

--- a/spring-cloud-cloud-foundry-connector.html
+++ b/spring-cloud-cloud-foundry-connector.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Cloud Foundry Connector</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -479,9 +479,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlight"><code class="language-json" data-lang="json">"p-rabbitmq": [
  {
   "credentials": {
-   "http_api_uri": "http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api",
+   "http_api_uri": "https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api",
    "http_api_uris": [
-    "http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api"
+    "https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api"
    ],
    "uri": "amqp://ca30db57-a396:ddrnu58423q@12.34.567.89/322e7782-eb1f",
    "uris": [

--- a/spring-cloud-connectors.html
+++ b/spring-cloud-connectors.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Connectors</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -527,7 +527,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="ulist">
 <ul>
 <li>
-<p><strong>Spring Cloud Cloud Foundry Connector</strong>: Connector for <a href="http://cloudfoundry.org/">Cloud Foundry</a>.</p>
+<p><strong>Spring Cloud Cloud Foundry Connector</strong>: Connector for <a href="https://cloudfoundry.org/">Cloud Foundry</a>.</p>
 </li>
 <li>
 <p><strong>Spring Cloud Heroku Connector</strong>: Connector for <a href="https://www.heroku.com/">Heroku</a>.</p>
@@ -806,7 +806,7 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 <div class="sect3">
 <h4 id="_providing_a_bootstrap_properties_file">Providing a Bootstrap Properties File</h4>
 <div class="paragraph">
-<p>To avoid having to manually configure run configurations or test runners with the path to the configuration properties file, the connector can read a templated filename out of the runtime classpath. This file must be named <code>spring-cloud-bootstrap.properties</code> and be located at the classpath root. For security, the connector will not attempt to read any service URIs out of the file. If the connector does find the file, it will read the property <code>spring.cloud.propertiesFile</code> and <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html">substitute the pattern <code>${system.property}</code></a> with the appropriate value from the system properties. The most useful option is generally <code>${user.home}</code>.</p>
+<p>To avoid having to manually configure run configurations or test runners with the path to the configuration properties file, the connector can read a templated filename out of the runtime classpath. This file must be named <code>spring-cloud-bootstrap.properties</code> and be located at the classpath root. For security, the connector will not attempt to read any service URIs out of the file. If the connector does find the file, it will read the property <code>spring.cloud.propertiesFile</code> and <a href="https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html">substitute the pattern <code>${system.property}</code></a> with the appropriate value from the system properties. The most useful option is generally <code>${user.home}</code>.</p>
 </div>
 <div class="paragraph">
 <p>A configuration properties file specified in the system properties will override any bootstrap file that may be available on the classpath.</p>
@@ -863,7 +863,7 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 <li>
 <p><strong>Cloud platform support.</strong> Out of the box, Spring Cloud Connectors offers support for the Cloud Foundry and Heroku platforms. You can extend Spring Cloud Connectors to provide support for other cloud platforms and providers.</p>
 <div class="paragraph">
-<p>Spring Cloud Connectors uses the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html"><code>CloudConnector</code></a> interface to provide cloud platform support. A <code>CloudConnector</code> implementation for a particular cloud platform is responsible for detecting when the application is running in that cloud platform, obtaining information about the application from the cloud platform, and obtaining information about the services that are bound to the application.</p>
+<p>Spring Cloud Connectors uses the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html"><code>CloudConnector</code></a> interface to provide cloud platform support. A <code>CloudConnector</code> implementation for a particular cloud platform is responsible for detecting when the application is running in that cloud platform, obtaining information about the application from the cloud platform, and obtaining information about the services that are bound to the application.</p>
 </div>
 </li>
 <li>
@@ -874,18 +874,18 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p>A <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html"><code>ServiceInfo</code></a> models the information required to connect to the service. In the case of a database service, a <code>ServiceInfo</code> implementation might include fields for host, port, database name, username, and password; in the case of a web service, it might include fields for URL and API key.</p>
+<p>A <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html"><code>ServiceInfo</code></a> models the information required to connect to the service. In the case of a database service, a <code>ServiceInfo</code> implementation might include fields for host, port, database name, username, and password; in the case of a web service, it might include fields for URL and API key.</p>
 </li>
 <li>
-<p>A <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html"><code>ServiceInfoCreator</code></a> creates <code>ServiceInfo</code> objects based on the service information collected by a cloud connector. A <code>ServiceInfoCreator</code> implementation is specific to a cloud platform.</p>
+<p>A <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html"><code>ServiceInfoCreator</code></a> creates <code>ServiceInfo</code> objects based on the service information collected by a cloud connector. A <code>ServiceInfoCreator</code> implementation is specific to a cloud platform.</p>
 </li>
 </ul>
 </div>
 </li>
 <li>
-<p><strong>Application framework support.</strong> The <a href="spring-cloud-spring-service-connector.html">Spring Cloud Spring Service Connector</a> creates service connectors with <a href="http://projects.spring.io/spring-data/">Spring Data</a> data types. You can extend Spring Cloud Connectors to provide service connection objects using another framework.</p>
+<p><strong>Application framework support.</strong> The <a href="spring-cloud-spring-service-connector.html">Spring Cloud Spring Service Connector</a> creates service connectors with <a href="https://projects.spring.io/spring-data/">Spring Data</a> data types. You can extend Spring Cloud Connectors to provide service connection objects using another framework.</p>
 <div class="paragraph">
-<p>Spring Cloud Connectors uses the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html"><code>ServiceConnectorCreator</code></a> interface to provide framework support. A <code>ServiceConnectorCreator</code> creates service connectors using the service connection information provided by a <code>ServiceInfo</code> object.</p>
+<p>Spring Cloud Connectors uses the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html"><code>ServiceConnectorCreator</code></a> interface to provide framework support. A <code>ServiceConnectorCreator</code> creates service connectors using the service connection information provided by a <code>ServiceInfo</code> object.</p>
 </div>
 </li>
 </ol>
@@ -917,7 +917,7 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 <p>Spring Cloud Connectors uses the <a href="https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html">Java SPI</a> to discover available connectors.</p>
 </div>
 <div class="paragraph">
-<p>Your connector class must implement the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html"><code>CloudConnector</code></a> interface, which includes three methods:</p>
+<p>Your connector class must implement the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html"><code>CloudConnector</code></a> interface, which includes three methods:</p>
 </div>
 <div class="ulist">
 <ul>
@@ -948,7 +948,7 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 <div class="sect2">
 <h3 id="_adding_service_support">Adding Service Support</h3>
 <div class="paragraph">
-<p>To allow Spring Cloud Connectors to discover a new type of service, create a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html"><code>ServiceInfo</code></a> class containing the information necessary to connect to the service. If your service can be specified via a URI, extend <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html"><code>UriBasedServiceInfo</code></a> and provide the URI scheme in a call to the <code>super</code> constructor.</p>
+<p>To allow Spring Cloud Connectors to discover a new type of service, create a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html"><code>ServiceInfo</code></a> class containing the information necessary to connect to the service. If your service can be specified via a URI, extend <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html"><code>UriBasedServiceInfo</code></a> and provide the URI scheme in a call to the <code>super</code> constructor.</p>
 </div>
 <div class="paragraph">
 <p>The following class will expose information for a <code>HelloWorldService</code> available at <code>helloworld://username:password@host:port/Bonjour</code>.</p>
@@ -971,7 +971,7 @@ spring.cloud.database: mysql://user:pass@host:1234/dbname</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>After creating the <code>ServiceInfo</code> class, you will need to create a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html"><code>ServiceInfoCreator</code></a> for each cloud platform you want to support. If you are adding service support for a cloud platform already supported by Spring Cloud Connectors, you will probably want to extend the appropriate creator base class(es).</p>
+<p>After creating the <code>ServiceInfo</code> class, you will need to create a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html"><code>ServiceInfoCreator</code></a> for each cloud platform you want to support. If you are adding service support for a cloud platform already supported by Spring Cloud Connectors, you will probably want to extend the appropriate creator base class(es).</p>
 </div>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
@@ -1051,7 +1051,7 @@ public HelloWorldServiceInfo createServiceInfo(String id, String uri) {
 </table>
 </div>
 <div class="paragraph">
-<p>Your connector class must implement the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html"><code>ServiceConnectorCreator</code></a> interface, which has three methods:</p>
+<p>Your connector class must implement the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html"><code>ServiceConnectorCreator</code></a> interface, which has three methods:</p>
 </div>
 <div class="ulist">
 <ul>

--- a/spring-cloud-core.html
+++ b/spring-cloud-core.html
@@ -8,7 +8,7 @@
 <title>Untitled</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -409,7 +409,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-/* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
+/* Stylesheet for CodeRay to match GitHub theme | MIT License | https://foundation.zurb.com */
 /*pre.CodeRay {background-color:#f7f7f8;}*/
 .CodeRay .line-numbers{border-right:1px solid #d8d8d8;padding:0 0.5em 0 .25em}
 .CodeRay span.line-numbers{display:inline-block;margin-right:.5em;color:rgba(0,0,0,.3)}

--- a/spring-cloud-heroku-connector.html
+++ b/spring-cloud-heroku-connector.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Heroku Connector</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/spring-cloud-spring-service-connector.html
+++ b/spring-cloud-spring-service-connector.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Spring Service Connector</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -467,7 +467,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>The Spring Service Connector is part of the <a href="spring-cloud-connectors.html">Spring Cloud Connectors</a> project.</p>
 </div>
 <div class="paragraph">
-<p>This library provides <code>ServiceConnectorCreator</code> implementations for <code>javax.sql.DataSource</code> and various <a href="http://projects.spring.io/spring-data/">Spring Data</a> connector factories. It also provides Java configuration and XML namespace support for connecting to cloud services, accessing cloud services, and accessing application properties.</p>
+<p>This library provides <code>ServiceConnectorCreator</code> implementations for <code>javax.sql.DataSource</code> and various <a href="https://projects.spring.io/spring-data/">Spring Data</a> connector factories. It also provides Java configuration and XML namespace support for connecting to cloud services, accessing cloud services, and accessing application properties.</p>
 </div>
 </div>
 </div>
@@ -497,7 +497,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_creating_service_beans">Creating Service Beans</h3>
 <div class="paragraph">
-<p>If you do not wish to extend <code>AbstractCloudConfig</code>, you can create your own <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html"><code>Cloud</code></a> object as an alternative.</p>
+<p>If you do not wish to extend <code>AbstractCloudConfig</code>, you can create your own <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html"><code>Cloud</code></a> object as an alternative.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -508,7 +508,7 @@ public Cloud cloud() {
 </div>
 </div>
 <div class="paragraph">
-<p>The following example creates a <code>DataSource</code> bean (without configuration) using the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html#getSingletonServiceConnector(java.lang.Class,%20org.springframework.cloud.service.ServiceConnectorConfig)"><code>getSingletonServiceConnector()</code></a> method on <code>Cloud</code>.</p>
+<p>The following example creates a <code>DataSource</code> bean (without configuration) using the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html#getSingletonServiceConnector(java.lang.Class,%20org.springframework.cloud.service.ServiceConnectorConfig)"><code>getSingletonServiceConnector()</code></a> method on <code>Cloud</code>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -534,7 +534,7 @@ public DataSource dataSource() {
 </table>
 </div>
 <div class="paragraph">
-<p>The configuration shown in the following example creates a <code>DataSource</code> bean that connects to the only relational database service bound to the application (it will fail if there is no such unique service). It also creates a <code>MongoDbFactory</code> bean, which again connects to the only MongoDB service bound to the application. (For ways to connect to other services, see the <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html">Javadoc for <code>AbstractCloudConfig.ServiceConnectionFactory</code></a>.)</p>
+<p>The configuration shown in the following example creates a <code>DataSource</code> bean that connects to the only relational database service bound to the application (it will fail if there is no such unique service). It also creates a <code>MongoDbFactory</code> bean, which again connects to the only MongoDB service bound to the application. (For ways to connect to other services, see the <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html">Javadoc for <code>AbstractCloudConfig.ServiceConnectionFactory</code></a>.)</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -614,7 +614,7 @@ public RabbitConnectionFactory rabbitFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To provide configuration for a RabbitMQ service, you can use an overloaded <code>rabbitConnectionFactory()</code> variant. The following example connects to the <code>bunnymq</code> RabbitMQ service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html"><code>RabbitConnectionFactoryConfig</code></a>, which is initialized with a <code>channelCacheSize</code> of 10.</p>
+<p>To provide configuration for a RabbitMQ service, you can use an overloaded <code>rabbitConnectionFactory()</code> variant. The following example connects to the <code>bunnymq</code> RabbitMQ service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html"><code>RabbitConnectionFactoryConfig</code></a>, which is initialized with a <code>channelCacheSize</code> of 10.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -627,7 +627,7 @@ public RabbitConnectionFactory rabbitFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To set properties on a RabbitMQ service, you can use an overloaded variant of <code>rabbitConnectionFactory()</code>. The following example connects to the <code>bunnymq</code> RabbitMQ service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html"><code>RabbitConnectionFactoryConfig</code></a>, which is initialized with a <code>HashMap</code> of property keys and values.</p>
+<p>To set properties on a RabbitMQ service, you can use an overloaded variant of <code>rabbitConnectionFactory()</code>. The following example connects to the <code>bunnymq</code> RabbitMQ service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html"><code>RabbitConnectionFactoryConfig</code></a>, which is initialized with a <code>HashMap</code> of property keys and values.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -685,7 +685,7 @@ public DataSource dataSource() {
 </div>
 </div>
 <div class="paragraph">
-<p>To provide configuration for a relational database service, you can use an overloaded <code>dataSource()</code> variant. The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000.</p>
+<p>To provide configuration for a relational database service, you can use an overloaded <code>dataSource()</code> variant. The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -699,7 +699,7 @@ public DataSource dataSource() {
 </div>
 </div>
 <div class="paragraph">
-<p>To set properties on a relational database service, you can use an overloaded variant of <code>dataSource()</code>. The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>. The <code>DataSourceConfig</code> is initialized with a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> (which sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000) and a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html"><code>ConnectionConfig</code></a> (which sets the <code>useUnicode</code> and <code>characterEncoding</code> properties).</p>
+<p>To set properties on a relational database service, you can use an overloaded variant of <code>dataSource()</code>. The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>. The <code>DataSourceConfig</code> is initialized with a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> (which sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000) and a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html"><code>ConnectionConfig</code></a> (which sets the <code>useUnicode</code> and <code>characterEncoding</code> properties).</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -730,12 +730,12 @@ public DataSource dataSource() {
 <p><a href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC Connection Pool</a></p>
 </li>
 <li>
-<p><a href="http://brettwooldridge.github.io/HikariCP/">HikariCP</a></p>
+<p><a href="https://brettwooldridge.github.io/HikariCP/">HikariCP</a></p>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html"><code>SimpleDriverDataSource</code></a>, which does not reuse connections.</p>
+<p>The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a <a href="https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html"><code>SimpleDriverDataSource</code></a>, which does not reuse connections.</p>
 </div>
 <div class="sect5">
 <h6 id="_reordering_implementation_priority">Reordering Implementation Priority</h6>
@@ -754,10 +754,10 @@ public DataSource dataSource() {
 </table>
 </div>
 <div class="paragraph">
-<p>If you would like to reorder the priorities given to supported <code>DataSource</code> implementations, you can provide a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a> containing a <code>List</code> which uses your own ordering. You can name an implementation either by its full class name or by a string included in its class name.</p>
+<p>If you would like to reorder the priorities given to supported <code>DataSource</code> implementations, you can provide a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a> containing a <code>List</code> which uses your own ordering. You can name an implementation either by its full class name or by a string included in its class name.</p>
 </div>
 <div class="paragraph">
-<p>The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <code>List</code> of <code>DataSource</code> implementation class names.</p>
+<p>The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <code>List</code> of <code>DataSource</code> implementation class names.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -771,7 +771,7 @@ public DataSource dataSource() {
 </div>
 </div>
 <div class="paragraph">
-<p>The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <code>List</code> of strings contained in <code>DataSource</code> implementations&#8217; class names.</p>
+<p>The following example connects to the <code>my-own-personal-sql</code> MySQL service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html"><code>DataSourceConfig</code></a>, which is initialized with a <code>List</code> of strings contained in <code>DataSource</code> implementations&#8217; class names.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -802,7 +802,7 @@ public MongoDbFactory mongoFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To provide configuration for a unique MongoDB service, you can use an overloaded <code>mongoDbFactory()</code> variant. The following example connects to the only MongoDB service bound to the application and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html"><code>MongoDbFactoryConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
+<p>To provide configuration for a unique MongoDB service, you can use an overloaded <code>mongoDbFactory()</code> variant. The following example connects to the only MongoDB service bound to the application and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html"><code>MongoDbFactoryConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -827,7 +827,7 @@ public MongoDbFactory mongoFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific MongoDB service and provide configuration, you can use an overloaded <code>mongoDbFactory()</code> variant. The following example connects to the <code>mongo-service</code> MongoDB service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html"><code>MongoDbFactoryConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
+<p>To connect to a specific MongoDB service and provide configuration, you can use an overloaded <code>mongoDbFactory()</code> variant. The following example connects to the <code>mongo-service</code> MongoDB service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html"><code>MongoDbFactoryConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -855,7 +855,7 @@ public RedisConnectionFactory redisFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To provide configuration for a unique Redis service, you can use an overloaded <code>redisConnectionFactory()</code> variant. The following example connects to the only Redis service bound to the application and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html"><code>PooledServiceConnectorConfig</code></a>, which is initialized with a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000.</p>
+<p>To provide configuration for a unique Redis service, you can use an overloaded <code>redisConnectionFactory()</code> variant. The following example connects to the only Redis service bound to the application and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html"><code>PooledServiceConnectorConfig</code></a>, which is initialized with a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets a <code>minPoolSize</code> of 5, a <code>maxPoolSize</code> of 30, and a <code>maxWaitTime</code> of 3000.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -881,7 +881,7 @@ public RedisConnectionFactory redisFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific Redis service and provide configuration, you can use an overloaded <code>redisConnectionFactory()</code> variant. The following example connects to the <code>redis-service</code> Redis service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a>, which is initialized with a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
+<p>To connect to a specific Redis service and provide configuration, you can use an overloaded <code>redisConnectionFactory()</code> variant. The following example connects to the <code>redis-service</code> Redis service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a>, which is initialized with a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> that sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -895,7 +895,7 @@ public RedisConnectionFactory redisFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific Redis service and set properties on the service, you can use an overloaded variant of <code>redisConnectionFactory()</code>. The following example connects to the <code>redis-service</code> Redis service and sets the <code>timeout</code> property using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a> initialized with a <code>HashMap</code> that contains the property key and value.</p>
+<p>To connect to a specific Redis service and set properties on the service, you can use an overloaded variant of <code>redisConnectionFactory()</code>. The following example connects to the <code>redis-service</code> Redis service and sets the <code>timeout</code> property using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a> initialized with a <code>HashMap</code> that contains the property key and value.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -910,7 +910,7 @@ public RedisConnectionFactory redisFactory() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific Redis service and provide configuration and property values for the service, you can use an overloaded variant of <code>redisConnectionFactory()</code>. The following example connects to the <code>redis-service</code> Redis service and uses a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a> initialized with a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> (which sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200) and a <code>HashMap</code> (which contains a property key and value) to configure the service and set its <code>timeout</code> property.</p>
+<p>To connect to a specific Redis service and provide configuration and property values for the service, you can use an overloaded variant of <code>redisConnectionFactory()</code>. The following example connects to the <code>redis-service</code> Redis service and uses a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html"><code>RedisConnectionFactoryConfig</code></a> initialized with a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html"><code>PoolConfig</code></a> (which sets <code>writeConcern</code> to <code>NONE</code>, <code>connectionsPerHost</code> to 50, and <code>maxWaitTime</code> to 200) and a <code>HashMap</code> (which contains a property key and value) to configure the service and set its <code>timeout</code> property.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -941,7 +941,7 @@ public Cluster cluster() {
 </div>
 </div>
 <div class="paragraph">
-<p>To provide configuration for a unique Cassandra service, you can use an overloaded <code>cluster()</code> variant. The following example connects to the only Cassandra service bound to the application and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html"><code>CassandraClusterConfig</code></a> with metrics and JMX reporting disabled.</p>
+<p>To provide configuration for a unique Cassandra service, you can use an overloaded <code>cluster()</code> variant. The following example connects to the only Cassandra service bound to the application and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html"><code>CassandraClusterConfig</code></a> with metrics and JMX reporting disabled.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -968,7 +968,7 @@ public Cluster cluster() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific Cassandra service and provide configuration, you can use an overloaded <code>cluster()</code> variant. The following example connects to the <code>cassandra-service</code> Cassandra service and supplies configuration using a <a href="http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html"><code>CassandraClusterConfig</code></a> with metrics and JMX reporting disabled.</p>
+<p>To connect to a specific Cassandra service and provide configuration, you can use an overloaded <code>cluster()</code> variant. The following example connects to the <code>cassandra-service</code> Cassandra service and supplies configuration using a <a href="https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html"><code>CassandraClusterConfig</code></a> with metrics and JMX reporting disabled.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -986,7 +986,7 @@ public Cluster cluster() {
 <div class="sect3">
 <h4 id="_smtp">SMTP</h4>
 <div class="paragraph">
-<p>To connect to a unique SMTP service, you can create a service bean using <code>service()</code>, providing the service type <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html"><code>MailSender</code></a>. The following example connects to the only SMTP service bound to the application.</p>
+<p>To connect to a unique SMTP service, you can create a service bean using <code>service()</code>, providing the service type <a href="https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html"><code>MailSender</code></a>. The following example connects to the only SMTP service bound to the application.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -998,7 +998,7 @@ public MailSender mailSender() {
 </div>
 </div>
 <div class="paragraph">
-<p>To connect to a specific SMTP service, you can use an overloaded variant of <code>service()</code>, providing the service type <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html"><code>MailSender</code></a>. The following example connects specifically to the <code>mail-service</code> SMTP service.</p>
+<p>To connect to a specific SMTP service, you can use an overloaded variant of <code>service()</code>, providing the service type <a href="https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html"><code>MailSender</code></a>. The following example connects specifically to the <code>mail-service</code> SMTP service.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -1094,8 +1094,8 @@ class CloudConfig {
 &lt;beans xmlns="http://www.springframework.org/schema/beans"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cloud="http://www.springframework.org/schema/cloud"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd"&gt;
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd"&gt;
 
 &lt;!-- &lt;cloud&gt; namespace usage here --&gt;</code></pre>
 </div>
@@ -1271,12 +1271,12 @@ class CloudConfig {
 <p><a href="https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html">Tomcat JDBC Connection Pool</a></p>
 </li>
 <li>
-<p><a href="http://brettwooldridge.github.io/HikariCP/">HikariCP</a></p>
+<p><a href="https://brettwooldridge.github.io/HikariCP/">HikariCP</a></p>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html"><code>SimpleDriverDataSource</code></a>, which does not reuse connections.</p>
+<p>The connector uses the first of these that is found on the classpath. If none of these are on the classpath, the connector falls back to a <a href="https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html"><code>SimpleDriverDataSource</code></a>, which does not reuse connections.</p>
 </div>
 <div class="sect5">
 <h6 id="_reordering_implementation_priority_2">Reordering Implementation Priority</h6>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://erik.eae.net/archives/2007/07/27/18.54.15/ (200) with 1 occurrences could not be migrated:  
   ([https](https://erik.eae.net/archives/2007/07/27/18.54.15/) result SSLHandshakeException).
* [ ] http://javascript.nwbox.com/IEContentLoaded/ (200) with 1 occurrences could not be migrated:  
   ([https](https://javascript.nwbox.com/IEContentLoaded/) result SSLHandshakeException).
* [ ] http://blindsignals.com/index.php/2009/07/jquery-delay/ (301) with 1 occurrences could not be migrated:  
   ([https](https://blindsignals.com/index.php/2009/07/jquery-delay/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://fontawesome.io (301) with 4 occurrences migrated to:  
  https://fontawesome.com?from=io ([https](https://fontawesome.io) result AnnotatedConnectException).
* [ ] http://jsperf.com/getall-vs-sizzle/2 (301) with 1 occurrences migrated to:  
  https://jsperf.com/getall-vs-sizzle/2 ([https](https://jsperf.com/getall-vs-sizzle/2) result ReadTimeoutException).
* [ ] http://wiki.ecmascript.org/doku.php?id=harmony:egal (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://wiki.ecmascript.org/doku.php?id=harmony:egal ([https](https://wiki.ecmascript.org/doku.php?id=harmony:egal) result ConnectTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* [ ] http://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api (UnknownHostException) with 2 occurrences migrated to:  
  https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api ([https](https://ca30db57-a396:ddrnu58423q@12.34.567.89:12345/api) result UnknownHostException).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/column/CassandraClusterConfig.html) result 404).
* [ ] http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/ (301) with 1 occurrences migrated to:  
  https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/ ([https](https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/) result 404).
* [ ] http://github.com/sprinframework (301) with 4 occurrences migrated to:  
  https://github.com/sprinframework ([https](https://github.com/sprinframework) result 404).
* [ ] http://github.com/spring_hadoop (301) with 4 occurrences migrated to:  
  https://github.com/spring_hadoop ([https](https://github.com/spring_hadoop) result 404).
* [ ] http://json.org/json2.js (404) with 1 occurrences migrated to:  
  https://json.org/json2.js ([https](https://json.org/json2.js) result 404).
* [ ] http://pivotal.github.com/jasmine (404) with 1 occurrences migrated to:  
  https://pivotal.github.com/jasmine ([https](https://pivotal.github.com/jasmine) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 8 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://backbonejs.org with 1 occurrences migrated to:  
  https://backbonejs.org ([https](https://backbonejs.org) result 200).
* [ ] http://brettwooldridge.github.io/HikariCP/ with 2 occurrences migrated to:  
  https://brettwooldridge.github.io/HikariCP/ ([https](https://brettwooldridge.github.io/HikariCP/) result 200).
* [ ] http://bugs.jquery.com/ticket/12282 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/12282 ([https](https://bugs.jquery.com/ticket/12282) result 200).
* [ ] http://bugs.jquery.com/ticket/12359 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/12359 ([https](https://bugs.jquery.com/ticket/12359) result 200).
* [ ] http://bugs.jquery.com/ticket/13378 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/13378 ([https](https://bugs.jquery.com/ticket/13378) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-heroku-connector.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-heroku-connector.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-heroku-connector.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-spring-service-connector.html) result 200).
* [ ] http://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html with 1 occurrences migrated to:  
  https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html ([https](https://commons.apache.org/proper/commons-lang/javadocs/api-release/index.html?org/apache/commons/lang3/text/StrSubstitutor.html) result 200).
* [ ] http://creativecommons.org/licenses/by/3.0/ with 2 occurrences migrated to:  
  https://creativecommons.org/licenses/by/3.0/ ([https](https://creativecommons.org/licenses/by/3.0/) result 200).
* [ ] http://diveintohtml5.info/history.html with 1 occurrences migrated to:  
  https://diveintohtml5.info/history.html ([https](https://diveintohtml5.info/history.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html with 3 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/1.1.2.BUILD-SNAPSHOT/api/org/springframework/cloud/service/keyval/RedisConnectionFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/CloudConnector.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/ServiceInfoCreator.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceConnectorCreator.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/index.html?org/springframework/cloud/service/ServiceInfo.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/Cloud.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/config/java/AbstractCloudConfig.ServiceConnectionFactory.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html with 5 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.PoolConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/PooledServiceConnectorConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/UriBasedServiceInfo.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/document/MongoDbFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html with 2 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/messaging/RabbitConnectionFactoryConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html with 1 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.ConnectionConfig.html) result 200).
* [ ] http://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html with 5 occurrences migrated to:  
  https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html ([https](https://docs.spring.io/autorepo/docs/spring-cloud/current/api/org/springframework/cloud/service/relational/DataSourceConfig.html) result 200).
* [ ] http://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/api/ ([https](https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/api/) result 200).
* [ ] http://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/reference/html/ ([https](https://docs.spring.io/spring-data/jpa/docs/1.3.4.RELEASE/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/api/ ([https](https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/api/) result 200).
* [ ] http://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/reference/html/ ([https](https://docs.spring.io/spring-data/jpa/docs/1.4.0.RC1/reference/html/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/SimpleDriverDataSource.html) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/mail/MailSender.html) result 200).
* [ ] http://foundation.zurb.com with 4 occurrences migrated to:  
  https://foundation.zurb.com ([https](https://foundation.zurb.com) result 200).
* [ ] http://github.com/spring-projects/gh-pages with 1 occurrences migrated to:  
  https://github.com/spring-projects/gh-pages ([https](https://github.com/spring-projects/gh-pages) result 200).
* [ ] http://imgs.mi9.com/uploads/landscape/2101/beautiful-leaf-wallpapers_1280x960_28083.jpg with 1 occurrences migrated to:  
  https://imgs.mi9.com/uploads/landscape/2101/beautiful-leaf-wallpapers_1280x960_28083.jpg ([https](https://imgs.mi9.com/uploads/landscape/2101/beautiful-leaf-wallpapers_1280x960_28083.jpg) result 200).
* [ ] http://jekyllrb.com with 1 occurrences migrated to:  
  https://jekyllrb.com ([https](https://jekyllrb.com) result 200).
* [ ] http://jquery.com/ with 1 occurrences migrated to:  
  https://jquery.com/ ([https](https://jquery.com/) result 200).
* [ ] http://opensource.org/licenses/mit-license.html with 2 occurrences migrated to:  
  https://opensource.org/licenses/mit-license.html ([https](https://opensource.org/licenses/mit-license.html) result 200).
* [ ] http://pages.github.com/ with 1 occurrences migrated to:  
  https://pages.github.com/ ([https](https://pages.github.com/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://rubygems.org with 1 occurrences migrated to:  
  https://rubygems.org ([https](https://rubygems.org) result 200).
* [ ] http://rubygems.org/ with 1 occurrences migrated to:  
  https://rubygems.org/ ([https](https://rubygems.org/) result 200).
* [ ] http://silviomoreto.github.io/bootstrap-select/ with 2 occurrences migrated to:  
  https://silviomoreto.github.io/bootstrap-select/ ([https](https://silviomoreto.github.io/bootstrap-select/) result 200).
* [ ] http://sizzlejs.com/ with 2 occurrences migrated to:  
  https://sizzlejs.com/ ([https](https://sizzlejs.com/) result 200).
* [ ] http://spring.io/guides/gs/gradle/ with 1 occurrences migrated to:  
  https://spring.io/guides/gs/gradle/ ([https](https://spring.io/guides/gs/gradle/) result 200).
* [ ] http://spring.io/guides/gs/maven/ with 1 occurrences migrated to:  
  https://spring.io/guides/gs/maven/ ([https](https://spring.io/guides/gs/maven/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-cloud-connectors with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-cloud-connectors ([https](https://stackoverflow.com/questions/tagged/spring-cloud-connectors) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-jpa with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-jpa ([https](https://stackoverflow.com/questions/tagged/spring-data-jpa) result 200).
* [ ] http://twitter.com/byscuits with 2 occurrences migrated to:  
  https://twitter.com/byscuits ([https](https://twitter.com/byscuits) result 200).
* [ ] http://twitter.com/fontawesome with 2 occurrences migrated to:  
  https://twitter.com/fontawesome ([https](https://twitter.com/fontawesome) result 200).
* [ ] http://underscorejs.org with 1 occurrences migrated to:  
  https://underscorejs.org ([https](https://underscorejs.org) result 200).
* [ ] http://kyruus.com (301) with 2 occurrences migrated to:  
  https://www.kyruus.com/ ([https](https://kyruus.com) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/cloud/spring-cloud.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/spring-cloud.xsd ([https](https://www.springframework.org/schema/cloud/spring-cloud.xsd) result 200).
* [ ] http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html ([https](https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html) result 200).
* [ ] http://www.w3.org/TR/2011/REC-css3-selectors-20110929/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/2011/REC-css3-selectors-20110929/ ([https](https://www.w3.org/TR/2011/REC-css3-selectors-20110929/) result 200).
* [ ] http://www.w3.org/TR/CSS21/syndata.html with 2 occurrences migrated to:  
  https://www.w3.org/TR/CSS21/syndata.html ([https](https://www.w3.org/TR/CSS21/syndata.html) result 200).
* [ ] http://www.w3.org/TR/selectors/ with 4 occurrences migrated to:  
  https://www.w3.org/TR/selectors/ ([https](https://www.w3.org/TR/selectors/) result 200).
* [ ] http://cloudfoundry.org/ with 1 occurrences migrated to:  
  https://cloudfoundry.org/ ([https](https://cloudfoundry.org/) result 301).
* [ ] http://dev.w3.org/csswg/cssom/ with 1 occurrences migrated to:  
  https://dev.w3.org/csswg/cssom/ ([https](https://dev.w3.org/csswg/cssom/) result 301).
* [ ] http://docs.python.org/library/functions.html with 1 occurrences migrated to:  
  https://docs.python.org/library/functions.html ([https](https://docs.python.org/library/functions.html) result 301).
* [ ] http://forum.spring.io/forum/spring-projects/data with 1 occurrences migrated to:  
  https://forum.spring.io/forum/spring-projects/data ([https](https://forum.spring.io/forum/spring-projects/data) result 301).
* [ ] http://github.com/SpringSource/spring-data-jpa with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-data-jpa ([https](https://github.com/SpringSource/spring-data-jpa) result 301).
* [ ] http://github.com/pivotal/jasmine-ajax with 1 occurrences migrated to:  
  https://github.com/pivotal/jasmine-ajax ([https](https://github.com/pivotal/jasmine-ajax) result 301).
* [ ] http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_ with 1 occurrences migrated to:  
  https://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_ ([https](https://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_) result 301).
* [ ] http://jira.springsource.org/browse/DATAJPA with 1 occurrences migrated to:  
  https://jira.springsource.org/browse/DATAJPA ([https](https://jira.springsource.org/browse/DATAJPA) result 301).
* [ ] http://jquery.org/license with 2 occurrences migrated to:  
  https://jquery.org/license ([https](https://jquery.org/license) result 301).
* [ ] http://projects.spring.io/spring-data-jpa with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-jpa ([https](https://projects.spring.io/spring-data-jpa) result 301).
* [ ] http://spring-projects.github.io/ with 1 occurrences migrated to:  
  https://spring-projects.github.io/ ([https](https://spring-projects.github.io/) result 301).
* [ ] http://twitter.github.com/bootstrap/javascript.html with 13 occurrences migrated to:  
  https://twitter.github.com/bootstrap/javascript.html ([https](https://twitter.github.com/bootstrap/javascript.html) result 301).
* [ ] http://www.modernizr.com/ with 1 occurrences migrated to:  
  https://www.modernizr.com/ ([https](https://www.modernizr.com/) result 301).
* [ ] http://www.spring.io with 8 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* [ ] http://www.w3.org/TR/css3-selectors/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/css3-selectors/ ([https](https://www.w3.org/TR/css3-selectors/) result 301).
* [ ] http://www.w3.org/TR/css3-syntax/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/css3-syntax/ ([https](https://www.w3.org/TR/css3-syntax/) result 301).
* [ ] http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx with 2 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx ([https](https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx) result 302).
* [ ] http://repo.spring.io/milestone with 4 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://scripts.sil.org/OFL with 2 occurrences migrated to:  
  https://scripts.sil.org/OFL ([https](https://scripts.sil.org/OFL) result 302).
* [ ] http://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context with 1 occurrences migrated to:  
  https://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context ([https](https://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:4000/spring-xyz/ with 1 occurrences
* http://www with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/cloud with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences