### PR TITLE
Allow user without password in UriInfo.

### DIFF
--- a/spring-cloud-core/src/main/java/org/springframework/cloud/util/UriInfo.java
+++ b/spring-cloud-core/src/main/java/org/springframework/cloud/util/UriInfo.java
@@ -129,7 +129,9 @@ public class UriInfo {
 
 		if (userInfo != null) {
 			String[] userPass = userInfo.split(":");
-			if (userPass.length != 2) {
+			if (userPass.length == 1) {
+				return new String[]{userPass[0], null};
+			} else if (userPass.length != 2) {
 				throw new IllegalArgumentException("Bad userinfo in URI: " + uri);
 			}
 			return userPass;

--- a/spring-cloud-core/src/test/java/org/springframework/cloud/StandardUriInfoFactoryTest.java
+++ b/spring-cloud-core/src/test/java/org/springframework/cloud/StandardUriInfoFactoryTest.java
@@ -40,10 +40,13 @@ public class StandardUriInfoFactoryTest {
 		assertEquals(uri, result.getUriString());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void createWithUsernameNoPassword() {
 		String uri = "mysql://joe@localhost:1527/big_db";
-		factory.createUri(uri);
+		UriInfo result = factory.createUri(uri);
+
+		assertUriInfoEquals(result, "localhost", 1527, "joe", null, "big_db", null);
+		assertEquals(uri, result.getUriString());
 	}
 
 	@Test

--- a/spring-cloud-core/src/test/java/org/springframework/cloud/service/common/RelationalServiceInfoTest.java
+++ b/spring-cloud-core/src/test/java/org/springframework/cloud/service/common/RelationalServiceInfoTest.java
@@ -35,9 +35,11 @@ public class RelationalServiceInfoTest {
 		assertEquals("jdbc:jdbcdbtype://hostname:1234/database", serviceInfo.getJdbcUrl());
 	}
 
-	@Test(expected = java.lang.IllegalArgumentException.class)
+	@Test
 	public void jdbcUrlNoPassword() {
-		createServiceInfo("dbtype://username@hostname/database");
+		RelationalServiceInfo serviceInfo = createServiceInfo("dbtype://username@hostname/database");
+
+		assertEquals("jdbc:jdbcdbtype://hostname/database?user=username", serviceInfo.getJdbcUrl());
 	}
 
 	@Test


### PR DESCRIPTION
I was trying to connect to a local database (used for testing) with a username and no a password in the URL, but `UriInfo` disallows that currently. I think this should be allowed for local testing.

This pull request modifies `UriInfo` to allow empty password.